### PR TITLE
send 'cmd*' to provoke sending priv-lvl by the server

### DIFF
--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -488,6 +488,7 @@ int pam_sm_acct_mgmt (pam_handle_t * pamh, int flags,
     tac_add_attrib(&attr, "service", tac_service);
     if(tac_protocol != NULL && tac_protocol[0] != '\0')
       tac_add_attrib(&attr, "protocol", tac_protocol);
+    tac_add_attrib_pair(&attr, "cmd", '*', "");
 
     tac_fd = tac_connect_single(active_server.addr, active_server.key);
     if(tac_fd < 0) {


### PR DESCRIPTION
Normally, client sends 'exec' query to the server to receive 'priv-lvl'
attribute. In order to provoke sending default priv-lvl by the server at
autorizaton stage we send 'cmd*' attribute