### PR TITLE
Password change support for TACACS+

### DIFF
--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -75,7 +75,9 @@ struct tac_attrib {
 struct areply {
     struct tac_attrib *attr;
     char *msg;
-    int status;
+    int status : 8;
+    int flags : 8;
+    int seq_no : 8;
 };
 
 #ifndef TAC_PLUS_MAXSERVERS		
@@ -130,9 +132,10 @@ int tac_connect_single(struct addrinfo *, const char *, struct addrinfo *, int);
 char *tac_ntop(const struct sockaddr *);
 
 int tac_authen_send(int, const char *, char *, char *,
-    char *);
-int tac_authen_read(int);
-int tac_cont_send(int, char *);
+    char *, u_char);
+int tac_authen_read(int, struct areply *);
+int tac_cont_send_seq(int, char *, int);
+#define tac_cont_send(fd, pass) tac_cont_send_seq((fd), (pass), 3)
 HDR *_tac_req_header(u_char, int);
 void _tac_crypt(u_char *, HDR *, int);
 u_char *_tac_md5_pad(int, HDR *);

--- a/libtac/lib/authen_s.c
+++ b/libtac/lib/authen_s.c
@@ -34,7 +34,7 @@
  *             LIBTAC_STATUS_ASSEMBLY_ERR
  */
 int tac_authen_send(int fd, const char *user, char *pass, char *tty,
-    char *r_addr) {
+    char *r_addr, u_char action) {
 
     HDR *th;    /* TACACS+ packet header */
     struct authen_start tb;     /* message body */
@@ -88,11 +88,11 @@ int tac_authen_send(int fd, const char *user, char *pass, char *tty,
     token_len = strlen(token);
 
     /* fill the body of message */
-    tb.action = TAC_PLUS_AUTHEN_LOGIN;
+    tb.action = action;
     tb.priv_lvl = tac_priv_lvl;
     if (!*tac_login) {
         /* default to PAP */
-        tb.authen_type = TAC_PLUS_AUTHEN_TYPE_PAP;
+        tb.authen_type = TAC_PLUS_AUTHEN_CHPASS == action ? TAC_PLUS_AUTHEN_TYPE_ASCII : TAC_PLUS_AUTHEN_TYPE_PAP;
     } else {
         if (!strcmp(tac_login,"chap")) {
             tb.authen_type = TAC_PLUS_AUTHEN_TYPE_CHAP;
@@ -168,3 +168,5 @@ int tac_authen_send(int fd, const char *user, char *pass, char *tty,
     TACDEBUG((LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret))
     return ret;
 }    /* tac_authen_send */
+
+

--- a/libtac/lib/cont_s.c
+++ b/libtac/lib/cont_s.c
@@ -31,7 +31,7 @@
  *         LIBTAC_STATUS_WRITE_TIMEOUT  (pending impl)
  *         LIBTAC_STATUS_ASSEMBLY_ERR
  */
-int tac_cont_send(int fd, char *pass) {
+int tac_cont_send_seq(int fd, char *pass, int seq) {
     HDR *th;        /* TACACS+ packet header */
     struct authen_cont tb;  /* continue body */
     int pass_len, bodylength, w;
@@ -43,7 +43,7 @@ int tac_cont_send(int fd, char *pass) {
 
     /* set some header options */
     th->version = TAC_PLUS_VER_0;
-    th->seq_no = 3;       /* 1 = request, 2 = reply, 3 = continue, 4 = reply */
+    th->seq_no = seq;       /* 1 = request, 2 = reply, 3 = continue, 4 = reply */
     th->encryption = tac_encryption ? TAC_PLUS_ENCRYPTED_FLAG : TAC_PLUS_UNENCRYPTED_FLAG;
 
     /* get size of submitted data */

--- a/libtac/lib/hdr_check.c
+++ b/libtac/lib/hdr_check.c
@@ -35,8 +35,8 @@ char *_tac_check_header(HDR *th, int type) {
             "%s: unrelated reply, type %d, expected %d",\
             __FUNCTION__, th->type, type))
         return protocol_err_msg;
-    } else if((th->seq_no != 2) && (th->seq_no != 4)) {
-        TACSYSLOG((LOG_ERR, "%s: not a reply - seq_no %d != {2,4}",\
+    } else if (1 == (th->seq_no % 2)) {
+        TACSYSLOG((LOG_ERR, "%s: not a reply - seq_no %d not even",\
             __FUNCTION__, th->seq_no))
         return protocol_err_msg;
     } /* else if(ntohl(th->session_id) != session_id) {

--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -63,14 +63,16 @@ magic_init()
     magic_initialised = 1;
 }
 
+#include <pthread.h>
 /*
  * magic - Returns the next magic number.
  */
 u_int32_t
 magic()
 {
-    if(!magic_initialised)
-        magic_init();
+    static pthread_once_t magic_control = PTHREAD_ONCE_INIT;
+    
+    pthread_once(&magic_control, &magic_init);
 
     return (u_int32_t)random();
 }

--- a/libtac/lib/messages.c
+++ b/libtac/lib/messages.c
@@ -20,6 +20,7 @@
  */
 
 char *protocol_err_msg = "(Protocol error)";
+char *authen_syserr_msg = "(Authentication system error)";
 char *author_ok_msg = "(Service granted)";
 char *author_fail_msg = "(Service not allowed)";
 char *author_err_msg = "(Service not allowed. Server error)";

--- a/libtac/lib/messages.h
+++ b/libtac/lib/messages.h
@@ -23,6 +23,7 @@
 #define _MESSAGES_H
 
 extern char *protocol_err_msg;
+extern char *authen_syserr_msg;
 extern char *author_ok_msg;
 extern char *author_fail_msg;
 extern char *author_err_msg;

--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -271,14 +271,22 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
             _pam_log(LOG_ERR, "connection failed srv %d: %m", srv_i);
             continue;
         }
-        if (tac_authen_send(tac_fd, user, pass, tty, r_addr) < 0) {
+        if (tac_authen_send(tac_fd, user, pass, tty, r_addr, TAC_PLUS_AUTHEN_LOGIN) < 0) {
             close(tac_fd);
             _pam_log(LOG_ERR, "error sending auth req to TACACS+ server");
             continue;
         }
         communicating = 1;
         while (communicating) {
-            msg = tac_authen_read(tac_fd);
+            struct areply re = { .attr = NULL, .msg = NULL, status = 0, flags = 0 };
+            struct pam_message conv_msg = { .msg_style = 0, .msg = NULL };
+            struct pam_response *resp = NULL;
+
+            msg = tac_authen_read(tac_fd, &re);
+
+            if (NULL != re.msg) {
+                conv_msg.msg = re.msg;
+            }
 
             /* talk the protocol */
             switch (msg) {
@@ -286,7 +294,22 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
                     /* success */
                     if (ctrl & PAM_TAC_DEBUG)
                         syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_PASS");
+  
+                    if (NULL != conv_msg.msg) {
+                        int retval = -1;
 
+                        conv_msg.msg_style = PAM_TEXT_INFO;
+                        retval = converse(pamh, 1, &conv_msg, &resp);
+                        if (PAM_SUCCESS == retval) {
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                                syslog(LOG_DEBUG, "send msg=\"%s\"", conv_msg.msg);
+                        }
+                        else {
+                            _pam_log(LOG_WARNING, "%s: error sending msg=\"%s\", retval=%d",
+                                     __FUNCTION__, conv_msg.msg, retval);
+                        }
+
+                    }
                     status = PAM_SUCCESS;
                     communicating = 0;
                     active_server.addr = tac_srv[srv_i].addr;
@@ -294,24 +317,73 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
 
                     if (ctrl & PAM_TAC_DEBUG)
                         syslog(LOG_DEBUG, "%s: active srv %d", __FUNCTION__, srv_i);
+
                     break;
 
                 case TAC_PLUS_AUTHEN_STATUS_FAIL:
-                    /* forget it */
                     if (ctrl & PAM_TAC_DEBUG)
                         syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_FAIL");
 
+                    if (NULL != conv_msg.msg) {
+                        int retval = -1;
+
+                        conv_msg.msg_style = PAM_ERROR_MSG;
+                        retval = converse(pamh, 1, &conv_msg, &resp);
+                        if (PAM_SUCCESS == retval) {
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                                syslog(LOG_DEBUG, "send msg=\"%s\"", conv_msg.msg);
+                        }
+                        else {
+                            _pam_log(LOG_WARNING, "%s: error sending msg=\"%s\", retval=%d",
+                                     __FUNCTION__, conv_msg.msg, retval);
+                        }
+
+                    }
                     status = PAM_AUTH_ERR;
                     communicating = 0;
+
                     _pam_log(LOG_ERR, "auth failed: %d", msg);
+
                     break;
 
                 case TAC_PLUS_AUTHEN_STATUS_GETDATA:
-                    /* not implemented */
-                    if (ctrl & PAM_TAC_DEBUG)
+                    if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
                         syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_GETDATA");
 
-                    communicating = 0;
+                    if (NULL != conv_msg.msg) {
+                        int retval = -1;
+                        int echo_off = (0x1 == (re.flags & 0x1));
+                        
+                        conv_msg.msg_style = echo_off ? PAM_PROMPT_ECHO_OFF : PAM_PROMPT_ECHO_ON;
+                        retval = converse(pamh, 1, &conv_msg, &resp);
+                        if (PAM_SUCCESS == retval) {
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG)) 
+                                syslog(LOG_DEBUG, "sent msg=\"%s\", resp=\"%s\"",
+                                       conv_msg.msg, resp->resp);
+
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                                syslog(LOG_DEBUG, "%s: calling tac_cont_send", __FUNCTION__);
+
+                            if (0 > tac_cont_send_seq(tac_fd, resp->resp, re.seq_no + 1)) {
+                                _pam_log(LOG_ERR, "error sending continue req to TACACS+ server");
+                                status = PAM_AUTH_ERR;
+                                communicating = 0;
+                            }
+                        }
+                        else {
+                            _pam_log(LOG_WARNING, "%s: error sending msg=\"%s\", retval=%d (%s)",
+                                     __FUNCTION__, conv_msg.msg, retval, pam_strerror(pamh, retval));
+                            status = PAM_AUTH_ERR;
+                            communicating = 0;
+                        }
+                    }
+                    else { 
+                        syslog(LOG_ERR, "GETDATA response with no message, returning PAM_AUTH_ERR");
+
+                        status = PAM_AUTH_ERR;
+                        communicating = 0;
+                    }
+
                     break;
 
                 case TAC_PLUS_AUTHEN_STATUS_GETUSER:
@@ -332,7 +404,6 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
                     if (tac_cont_send(tac_fd, pass) < 0) {
                         _pam_log (LOG_ERR, "error sending continue req to TACACS+ server");
                         communicating = 0;
-                        break;
                     }
                     /* continue the while loop; go read tac response */
                     break;
@@ -381,6 +452,14 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
                     if (ctrl & PAM_TAC_DEBUG)
                         syslog(LOG_DEBUG, "tacacs status: unknown response 0x%02x", msg);
             }
+
+            if (NULL != resp) {
+                free(resp->resp);
+                free(resp);
+            }
+                
+            free(re.msg);
+
         }    /* end while(communicating) */
         close(tac_fd);
 
@@ -393,9 +472,11 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
     if (ctrl & PAM_TAC_DEBUG)
         syslog(LOG_DEBUG, "%s: exit with pam status: %d", __FUNCTION__, status);
 
-    bzero(pass, strlen (pass));
-    free(pass);
-    pass = NULL;
+    if (NULL != pass) {
+        bzero(pass, strlen (pass));
+        free(pass);
+        pass = NULL;
+    }
 
     return status;
 }    /* pam_sm_authenticate */
@@ -609,16 +690,290 @@ int pam_sm_close_session (pam_handle_t * pamh, int flags,
 #ifdef PAM_SM_PASSWORD
 /* no-op function for future use */
 PAM_EXTERN
-int pam_sm_chauthtok (pam_handle_t * pamh, int flags,
+int pam_sm_chauthtok(pam_handle_t * pamh, int flags,
     int argc, const char **argv) {
 
-    int ctrl = _pam_parse (argc, argv);
+    int ctrl, retval;
+    char *user;
+    char *pass;
+    char *tty;
+    char *r_addr;
+    const void *pam_pass = NULL;
+    int srv_i;
+    int tac_fd, status, msg, communicating;
+
+    user = pass = tty = r_addr = NULL;
+
+    ctrl = _pam_parse(argc, argv);
 
     if (ctrl & PAM_TAC_DEBUG)
         syslog (LOG_DEBUG, "%s: called (pam_tacplus v%u.%u.%u)"
             , __FUNCTION__, PAM_TAC_VMAJ, PAM_TAC_VMIN, PAM_TAC_VPAT);
 
-    return PAM_SUCCESS;
+    syslog(LOG_DEBUG, "%s(flags=%d, argc=%d)", __func__, flags, argc);
+
+    if ( /*(ctrl & (PAM_TAC_TRY_FIRST_PASS | PAM_TAC_USE_FIRST_PASS))
+        &&*/ (pam_get_item(pamh, PAM_OLDAUTHTOK, &pam_pass) == PAM_SUCCESS)
+        && (pam_pass != NULL) ) {
+         if ((pass = strdup(pam_pass)) == NULL)
+              return PAM_BUF_ERR;
+    } else if ((ctrl & PAM_TAC_USE_FIRST_PASS)) {
+         _pam_log(LOG_WARNING, "no forwarded password");
+         return PAM_PERM_DENIED;
+    }
+    else {
+        pass = strdup("");
+    }
+    
+    if ((user = _pam_get_user(pamh)) == NULL)
+        return PAM_USER_UNKNOWN;
+    
+    if (ctrl & PAM_TAC_DEBUG)
+        syslog(LOG_DEBUG, "%s: user [%s] obtained", __FUNCTION__, user);
+
+    tty = _pam_get_terminal(pamh);
+    if (!strncmp(tty, "/dev/", 5))
+        tty += 5;
+    if (ctrl & PAM_TAC_DEBUG)
+        syslog(LOG_DEBUG, "%s: tty [%s] obtained", __FUNCTION__, tty);
+
+    r_addr = _pam_get_rhost(pamh);
+    if (ctrl & PAM_TAC_DEBUG)
+        syslog(LOG_DEBUG, "%s: rhost [%s] obtained", __FUNCTION__, r_addr);
+
+    if (PAM_SILENT == (flags & PAM_SILENT)) {
+        status = PAM_AUTHTOK_ERR;
+        goto finish;
+    }
+
+    status = PAM_TRY_AGAIN;
+    for (srv_i = 0; srv_i < tac_srv_no; srv_i++) {
+        if (ctrl & PAM_TAC_DEBUG)
+            syslog(LOG_DEBUG, "%s: trying srv %d", __FUNCTION__, srv_i );
+
+        tac_fd = tac_connect_single(tac_srv[srv_i].addr, tac_srv[srv_i].key, NULL);
+        if (tac_fd < 0) {
+            _pam_log(LOG_ERR, "connection failed srv %d: %m", srv_i);
+            continue;
+        }
+        if (PAM_PRELIM_CHECK == (flags & PAM_PRELIM_CHECK)) {
+            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                syslog(LOG_DEBUG, "%s: finishing PAM_PRELIM_CHECK with srv %d",
+                       __FUNCTION__, srv_i);
+
+            close(tac_fd);
+            status = PAM_SUCCESS;
+            goto finish;
+        }
+
+        if (tac_authen_send(tac_fd, user, "", tty, r_addr, TAC_PLUS_AUTHEN_CHPASS) < 0) {
+            close(tac_fd);
+            _pam_log(LOG_ERR, "error sending auth req to TACACS+ server");
+            continue;
+        }
+        communicating = 1;
+        while (communicating) {
+            struct areply re = { .attr = NULL, .msg = NULL, status = 0, flags = 0 };
+            struct pam_message conv_msg = { .msg_style = 0, .msg = NULL };
+            struct pam_response *resp = NULL;
+
+            msg = tac_authen_read(tac_fd, &re);
+
+            if (NULL != re.msg) {
+                conv_msg.msg = re.msg;
+            }
+
+            /* talk the protocol */
+            switch (msg) {
+                case TAC_PLUS_AUTHEN_STATUS_PASS:
+                    /* success */
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_PASS");
+
+                    if (NULL != conv_msg.msg) {
+                        int retval = -1;
+
+                        conv_msg.msg_style = PAM_TEXT_INFO;
+                        retval = converse(pamh, 1, &conv_msg, &resp);
+                        if (PAM_SUCCESS == retval) {
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                                syslog(LOG_DEBUG, "send msg=\"%s\"", conv_msg.msg);
+                        }
+                        else {
+                            _pam_log(LOG_WARNING, "%s: error sending msg=\"%s\", retval=%d",
+                                     __FUNCTION__, conv_msg.msg, retval);
+                        }
+
+                    }
+                    status = PAM_SUCCESS;
+                    communicating = 0;
+
+                    active_server.addr = tac_srv[srv_i].addr;
+                    active_server.key = tac_srv[srv_i].key;
+
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "%s: active srv %d", __FUNCTION__, srv_i);
+
+                    break;
+
+                case TAC_PLUS_AUTHEN_STATUS_FAIL:
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_FAIL");
+
+                    if (NULL != conv_msg.msg) {
+                        int retval = -1;
+
+                        conv_msg.msg_style = PAM_ERROR_MSG;
+                        retval = converse(pamh, 1, &conv_msg, &resp);
+                        if (PAM_SUCCESS == retval) {
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                                syslog(LOG_DEBUG, "send msg=\"%s\"", conv_msg.msg);
+                        }
+                        else {
+                            _pam_log(LOG_WARNING, "%s: error sending msg=\"%s\", retval=%d",
+                                     __FUNCTION__, conv_msg.msg, retval);
+                        }
+
+                    }
+                    status = PAM_AUTHTOK_ERR;
+                    communicating = 0;
+
+                    _pam_log(LOG_ERR, "chauthtok failed: %d", msg);
+
+                    break;
+
+                case TAC_PLUS_AUTHEN_STATUS_GETDATA:
+                    if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_GETDATA");
+
+                    if (NULL != conv_msg.msg) {
+                        int retval = -1;
+                        int echo_off = (0x1 == (re.flags & 0x1));
+                        
+                        conv_msg.msg_style = echo_off ? PAM_PROMPT_ECHO_OFF : PAM_PROMPT_ECHO_ON;
+                        retval = converse(pamh, 1, &conv_msg, &resp);
+                        if (PAM_SUCCESS == retval) {
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG)) 
+                                syslog(LOG_DEBUG, "sent msg=\"%s\", resp=\"%s\"",
+                                       conv_msg.msg, resp->resp);
+
+                            if (PAM_TAC_DEBUG == (ctrl & PAM_TAC_DEBUG))
+                                syslog(LOG_DEBUG, "%s: calling tac_cont_send", __FUNCTION__);
+
+                            if (0 > tac_cont_send_seq(tac_fd, resp->resp, re.seq_no + 1)) {
+                                _pam_log(LOG_ERR, "error sending continue req to TACACS+ server");
+                                communicating = 0;
+                            }
+                        }
+                        else {
+                            _pam_log(LOG_WARNING, "%s: error sending msg=\"%s\", retval=%d",
+                                     __FUNCTION__, conv_msg.msg, retval);
+                            communicating = 0;
+                        }
+                    }
+                    else { 
+                        syslog(LOG_ERR, "GETDATA response with no message, returning PAM_TRY_AGAIN");
+                        communicating = 0;
+                    }
+
+                    break;
+
+                case TAC_PLUS_AUTHEN_STATUS_GETUSER:
+                    /* not implemented */
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_GETUSER");
+
+                    communicating = 0;
+                    break;
+
+                case TAC_PLUS_AUTHEN_STATUS_GETPASS:
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_GETPASS");
+
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "%s: calling tac_cont_send", __FUNCTION__);
+
+                    if (tac_cont_send(tac_fd, pass) < 0) {
+                        _pam_log (LOG_ERR, "error sending continue req to TACACS+ server");
+                        communicating = 0;
+                        break;
+                    }
+                    /* continue the while loop; go read tac response */
+                    break;
+
+                case TAC_PLUS_AUTHEN_STATUS_RESTART:
+                    /* try it again */
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_RESTART");
+
+                    /*
+                     * not implemented
+                     * WdJ: I *think* you can just do tac_authen_send(user, pass) again
+                     *      but I'm not sure
+                     */
+                    communicating = 0;
+                    break;
+
+                case TAC_PLUS_AUTHEN_STATUS_ERROR:
+                    /* server has problems */
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_ERROR");
+
+                    communicating = 0;
+                    break;
+
+                case TAC_PLUS_AUTHEN_STATUS_FOLLOW:
+                    /* server tells to try a different server address */
+                    /* not implemented */
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: TAC_PLUS_AUTHEN_STATUS_FOLLOW");
+
+                    communicating = 0;
+                    break;
+
+                default:
+                    if (msg < 0) {
+                        /* connection error */
+                        communicating = 0;
+                        if (ctrl & PAM_TAC_DEBUG)
+                            syslog(LOG_DEBUG, "error communicating with tacacs server");
+                        break;
+                    }
+
+                    /* unknown response code */
+                    communicating = 0;
+                    if (ctrl & PAM_TAC_DEBUG)
+                        syslog(LOG_DEBUG, "tacacs status: unknown response 0x%02x", msg);
+            }
+
+            if (NULL != resp) {
+                free(resp->resp);
+                free(resp);
+            }
+
+            free(re.msg);
+
+        }    /* end while(communicating) */
+        close(tac_fd);
+
+        if (status == PAM_SUCCESS || status == PAM_AUTHTOK_ERR)
+            break;
+    }
+
+finish:
+    if (status != PAM_SUCCESS && status != PAM_AUTHTOK_ERR)
+        _pam_log(LOG_ERR, "no more servers to connect");
+
+    if (ctrl & PAM_TAC_DEBUG)
+        syslog(LOG_DEBUG, "%s: exit with pam status: %d", __FUNCTION__, status);
+
+    if (NULL != pass) {
+        bzero(pass, strlen(pass));
+        free(pass);
+        pass = NULL;
+    }
+
+    return status;
 }    /* pam_sm_chauthtok */
 #endif
 


### PR DESCRIPTION
Allow pam_tacplus to do challenge/response authentication for TAC
backends that force password change during authentication flow. Also add
support for password change via 'passwd' by implementing
pam_sm_chauthtok. Amongst other things, this requires explicitly
managing the sequence number for compatability with some versions of
Cisco ACS.