### PR TITLE
Add installation of libtac to pam_tacplus.spec.in

### DIFF
--- a/pam_tacplus.spec.in
+++ b/pam_tacplus.spec.in
@@ -58,6 +58,7 @@ install -m 644 sample.pam $RPM_BUILD_ROOT/etc/pam.d/tacacs
 chmod 755 $RPM_BUILD_ROOT/%{_lib}/security/*.so*
 
 make install DESTDIR=$RPM_BUILD_ROOT
+chmod 755 $RPM_BUILD_ROOT/usr/local/include/libtac
 
 %clean
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT

--- a/pam_tacplus.spec.in
+++ b/pam_tacplus.spec.in
@@ -42,13 +42,16 @@ make
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/etc/pam.d
 mkdir -p $RPM_BUILD_ROOT/%{_lib}/security
+mkdir -p $RPM_BUILD_ROOT/usr/local/lib/security
 
 install -m 755 .libs/pam_tacplus.so \
                $RPM_BUILD_ROOT/%{_lib}/security/
-
+install -m 755 .libs/libtac.so \
+              $RPM_BUILD_ROOT/usr/local/lib/security/
 install -m 644 sample.pam $RPM_BUILD_ROOT/etc/pam.d/tacacs
 
 chmod 755 $RPM_BUILD_ROOT/%{_lib}/security/*.so*
+chmod 755 $RPM_BUILD_ROOT/usr/local/lib/security/
 
 %clean
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
@@ -56,8 +59,9 @@ chmod 755 $RPM_BUILD_ROOT/%{_lib}/security/*.so*
 %files
 %defattr(-,root,root)
 %attr(0755,root,root) /%{_lib}/security/*.so*
+%attr(0755,root,root) /usr/local/lib/security/*.so*
 %attr(0644,root,root) %config(noreplace) /etc/pam.d/tacacs
-%doc AUTHORS COPYING README ChangeLog
+%doc AUTHORS COPYING README.md ChangeLog
 
 %changelog
 * Thu Feb  2 2012 - Jeroen <jeroen@jeroennijhof.nl>

--- a/pam_tacplus.spec.in
+++ b/pam_tacplus.spec.in
@@ -30,6 +30,14 @@ Requires: pam
 %description
 PAM Tacacs+ module based on code produced by Pawel Krawczyk <pawel.krawczyk@hush.com> and Jeroen Nijhof <jeroen@jeroennijhof.nl>
 
+%package devel
+Group: Development/Libraries
+Summary: Development files for pam_tacplus
+Requires: pam_tacplus
+
+%description devel
+Development files for pam_tacplus.
+
 %prep
 %setup -q -a 0
 
@@ -42,26 +50,34 @@ make
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/etc/pam.d
 mkdir -p $RPM_BUILD_ROOT/%{_lib}/security
-mkdir -p $RPM_BUILD_ROOT/usr/local/lib/security
 
 install -m 755 .libs/pam_tacplus.so \
                $RPM_BUILD_ROOT/%{_lib}/security/
-install -m 755 .libs/libtac.so \
-              $RPM_BUILD_ROOT/usr/local/lib/security/
 install -m 644 sample.pam $RPM_BUILD_ROOT/etc/pam.d/tacacs
 
 chmod 755 $RPM_BUILD_ROOT/%{_lib}/security/*.so*
-chmod 755 $RPM_BUILD_ROOT/usr/local/lib/security/
+
+make install DESTDIR=$RPM_BUILD_ROOT
 
 %clean
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
-%attr(0755,root,root) /%{_lib}/security/*.so*
-%attr(0755,root,root) /usr/local/lib/security/*.so*
+%attr(0755,root,root) /%{_lib}/security/*.so
+%attr(0755,root,root) /usr/local/lib/*.so.*
 %attr(0644,root,root) %config(noreplace) /etc/pam.d/tacacs
 %doc AUTHORS COPYING README.md ChangeLog
+
+%files devel
+%defattr(-,root,root,-)
+%attr(755,root,root) /usr/local/bin/*
+%attr(644,root,root) /usr/local/include/*
+%attr(755,root,root) /usr/local/lib/*.so
+%attr(755,root,root) /usr/local/lib/*.la
+%attr(755,root,root) /usr/local/lib/security/*
+%attr(644,root,root) /usr/local/lib/pkgconfig/*
+%doc /usr/local/share/doc/*
 
 %changelog
 * Thu Feb  2 2012 - Jeroen <jeroen@jeroennijhof.nl>


### PR DESCRIPTION
Hi,

I'm building rpm for pam_tacplus library. And here are two issues which I've fixed to make it work:
1. Changed README -> README.md in pam_tacplus.spec.in in %doc section
2. .lib/libtac.so library is built but not mentioned in spec file. So I've added installation of libtac.so.*
3. Also to make nss_tacplus rpm, i've added pam_tacplus-devel package (contains headers and symlinks to libtac)

