### PR TITLE
Fix build breakage when compiling without openssl-devel

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,7 +54,7 @@ pam_tacplus_la_SOURCES = pam_tacplus.h \
 pam_tacplus.c \
 support.h \
 support.c
-pam_tacplus_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include
+pam_tacplus_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include -I $(top_srcdir)/libtac/lib
 pam_tacplus_la_LDFLAGS = -module -avoid-version
 pam_tacplus_la_LIBADD = libtac.la
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,10 +9,12 @@
 ACLOCAL_AMFLAGS = -I config
 AUTOMAKE_OPTIONS = subdir-objects
 
+if TACC
 bin_PROGRAMS = tacc
 tacc_SOURCES = tacc.c
 tacc_LDADD = libtac.la
 tacc_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include
+endif
 
 libtac_includedir = $(includedir)/libtac
 libtac_include_HEADERS = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,8 +36,6 @@ libtac/lib/hdr_check.c \
 libtac/lib/header.c \
 libtac/lib/magic.c \
 libtac/lib/magic.h \
-libtac/lib/md5.c \
-libtac/lib/md5.h \
 libtac/lib/messages.c \
 libtac/lib/messages.h \
 libtac/lib/read_wait.c \
@@ -45,6 +43,11 @@ libtac/lib/version.c \
 libtac/lib/xalloc.c \
 libtac/lib/xalloc.h \
 $(libtac_include_HEADERS)
+if MY_MD5
+libtac_la_SOURCES += \
+libtac/lib/md5.c \
+libtac/lib/md5.h
+endif
 libtac_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include
 libtac_la_LDFLAGS = -version-info 2:0:0 -shared
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,7 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h strings.h sys/socket.h sys/time.h ])
 AC_CHECK_HEADERS([syslog.h unistd.h openssl/md5.h openssl/rand.h linux/random.h sys/random.h])
 AC_CHECK_HEADER(security/pam_appl.h, [], [AC_MSG_ERROR([PAM libraries missing. Install with "yum install pam-devel" or "apt-get install libpam-dev".])] )
+AM_CONDITIONAL(MY_MD5, [test "$ac_cv_header_openssl_md5_h" = "no" ])
 
 dnl --------------------------------------------------------------------
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h str
 AC_CHECK_HEADERS([syslog.h unistd.h openssl/md5.h openssl/rand.h linux/random.h sys/random.h])
 AC_CHECK_HEADER(security/pam_appl.h, [], [AC_MSG_ERROR([PAM libraries missing. Install with "yum install pam-devel" or "apt-get install libpam-dev".])] )
 AM_CONDITIONAL(MY_MD5, [test "$ac_cv_header_openssl_md5_h" = "no" ])
+AM_CONDITIONAL(TACC, [test "$ac_cv_lib_crypto_RAND_pseudo_bytes" = "yes"])
 
 dnl --------------------------------------------------------------------
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/libtac/lib/authen_s.c
+++ b/libtac/lib/authen_s.c
@@ -28,9 +28,6 @@
 
 #if defined(HAVE_OPENSSL_MD5_H) && defined(HAVE_LIBCRYPTO)
 # include <openssl/md5.h>
-#ifndef MD5_LEN
-# define MD5_LEN MD5_LBLOCK
-#endif
 #else
 # include "md5.h"
 #endif
@@ -55,7 +52,7 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 	int pkt_len = 0;
 	int ret = 0;
 	char *chal = "1234123412341234";
-	char digest[MD5_LEN];
+	char digest[MD5_LBLOCK];
 	char *token = NULL;
 	u_char *pkt = NULL, *mdp = NULL;
 	MD5_CTX mdcontext;
@@ -93,10 +90,10 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 		MD5Final((u_char *) digest, &mdcontext);
 #endif
 		free(mdp);
-		token = (char*) xcalloc(1, sizeof(u_char) + 1 + chal_len + MD5_LEN);
+		token = (char*) xcalloc(1, sizeof(u_char) + 1 + chal_len + MD5_LBLOCK);
 		token[0] = 5;
 		memcpy(&token[1], chal, chal_len);
-		memcpy(token + chal_len + 1, digest, MD5_LEN);
+		memcpy(token + chal_len + 1, digest, MD5_LBLOCK);
 	} else {
 		token = xstrdup(pass);
 	}

--- a/libtac/lib/cont_s.c
+++ b/libtac/lib/cont_s.c
@@ -19,7 +19,11 @@
  */
 
 #include "libtac.h"
-#include "md5.h"
+#if defined(HAVE_OPENSSL_MD5_H) && defined(HAVE_LIBCRYPTO)
+# include <openssl/md5.h>
+#else
+# include "md5.h"
+#endif
 
 /* this function sends a continue packet do TACACS+ server, asking
  * for validation of given password

--- a/libtac/lib/md5.h
+++ b/libtac/lib/md5.h
@@ -34,12 +34,19 @@ typedef struct {
 } MD5_CTX;
 
 __BEGIN_DECLS
-void MD5Init__P((MD5_CTX*));
-void MD5Update__P((MD5_CTX*, unsigned char*, UINT4));
-void MD5Final__P((unsigned char[], MD5_CTX*));
+void MD5Init __P((MD5_CTX*));
+void MD5Update __P((MD5_CTX*, unsigned char*, UINT4));
+void MD5Final __P((unsigned char[], MD5_CTX*));
 __END_DECLS
 
 #define MD5_LEN 16
+
+/* forward compatibility with openssl/md5.h */
+#define MD5_Init MD5Init
+#define MD5_Update MD5Update
+#define MD5_Final MD5Final
+
+#define MD5_LBLOCK	MD5_LEN
 
 #define __MD5_INCLUDE__
 #endif /* __MD5_INCLUDE__ */


### PR DESCRIPTION
Make the target executable 'tacc' be dependent on having openssl/rand.h.

Fix the prototyping in lib/md5.h.

Accommodate the function name differences between lib/md5.h and
the equivalent functions in openssl/md5.h.

Accommodate replacement of MD5_LEN with MD5_LBLOCK (note that
MD5_CBLOCK and MD5_DIGEST_LEN aren't referenced).