### PR TITLE
Turn on stricter compiler warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@
 
 ACLOCAL_AMFLAGS = -I config
 AUTOMAKE_OPTIONS = subdir-objects
+AM_CFLAGS = -Wall -Wextra -Werror
 
 bin_PROGRAMS = tacc
 tacc_SOURCES = tacc.c

--- a/libtac/lib/acct_r.c
+++ b/libtac/lib/acct_r.c
@@ -98,7 +98,7 @@ int tac_acct_read(int fd, struct areply *re) {
     }
 
     spacket_read = read(fd, tb, ulen_from_header);
-    if(spacket_read < ulen_from_header) {
+    if(spacket_read < (ssize_t) ulen_from_header) {
         TACSYSLOG((LOG_ERR,\
             "%s: short reply body, read %zd of %zu: %m",\
             __FUNCTION__,\

--- a/libtac/lib/authen_r.c
+++ b/libtac/lib/authen_r.c
@@ -96,7 +96,7 @@ int tac_authen_read(int fd, struct areply *re) {
 		return re->status;
 	}
 	spacket_read = read(fd, tb, len_from_header);
-	if (spacket_read < len_from_header) {
+	if (spacket_read < (ssize_t) len_from_header) {
 		TACSYSLOG(
 				(LOG_ERR, "%s: short reply body, read %zd of %zu: %m", __FUNCTION__, spacket_read, len_from_header))
 		re->msg = xstrdup(authen_syserr_msg);

--- a/libtac/lib/author_r.c
+++ b/libtac/lib/author_r.c
@@ -103,7 +103,7 @@ int tac_author_read(int fd, struct areply *re) {
 		return re->status;
 	}
 	packet_read = read(fd, tb, len_from_header);
-	if (packet_read < len_from_header) {
+	if (packet_read < (ssize_t) len_from_header) {
 		TACSYSLOG(
 				(LOG_ERR, "%s: short reply body, read %zd of %zu", __FUNCTION__, packet_read, len_from_header))
 		re->msg = xstrdup(author_syserr_msg);
@@ -131,7 +131,7 @@ int tac_author_read(int fd, struct areply *re) {
 	/* cycle through the arguments supplied in the packet */
 	for (unsigned int r = 0; r < tb->arg_cnt && r < TAC_PLUS_MAX_ARGCOUNT;
 			r++) {
-		if (len_from_body > packet_read
+		if ((ssize_t) len_from_body > packet_read
 				|| ((void *) pktp - (void *) tb) > packet_read) {
 			TACSYSLOG(
 					(LOG_ERR, "%s: arguments supplied in packet seem to exceed its size", __FUNCTION__))
@@ -204,16 +204,16 @@ int tac_author_read(int fd, struct areply *re) {
 		 pktp points to current argument length */
 		for (unsigned int r = 0; r < tb->arg_cnt && r < TAC_PLUS_MAX_ARGCOUNT;
 				r++) {
-			unsigned char buff[256];
-			unsigned char *sep;
-			unsigned char *value;
-			unsigned char sepchar = '=';
+			char buff[256];
+			char *sep;
+			char *value;
+			char sepchar = '=';
 
-			bcopy(argp, buff, (int) *pktp);
-			buff[(int) *pktp] = '\0';
-			sep = strchr((const char *) buff, '=');
+			bcopy(argp, buff, *pktp);
+			buff[*pktp] = '\0';
+			sep = strchr(buff, '=');
 			if (sep == NULL) {
-				sep = strchr((const char *) buff, '*');
+				sep = strchr(buff, '*');
 			}
 			if (sep == NULL) {
 				TACSYSLOG(

--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -56,7 +56,7 @@ magic_init()
     if (!lstat("/dev/urandom", &statbuf) && S_ISCHR(statbuf.st_mode)) {
         int rfd = open("/dev/urandom", O_RDONLY);
         if(rfd >= 0) {
-            int nb_read = read(rfd, &seed, sizeof(seed));
+            (void) read(rfd, &seed, sizeof(seed));
             close(rfd);
         }
     }

--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -307,8 +307,6 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 							"tacacs status: TAC_PLUS_AUTHEN_STATUS_PASS");
 
 				if (NULL != conv_msg.msg) {
-					int retval = -1;
-
 					conv_msg.msg_style = PAM_TEXT_INFO;
 					retval = converse(pamh, 1, &conv_msg, &resp);
 					if (PAM_SUCCESS == retval) {
@@ -337,8 +335,6 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 							"tacacs status: TAC_PLUS_AUTHEN_STATUS_FAIL");
 
 				if (NULL != conv_msg.msg) {
-					int retval = -1;
-
 					conv_msg.msg_style = PAM_ERROR_MSG;
 					retval = converse(pamh, 1, &conv_msg, &resp);
 					if (PAM_SUCCESS == retval) {
@@ -364,7 +360,6 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 							"tacacs status: TAC_PLUS_AUTHEN_STATUS_GETDATA");
 
 				if (NULL != conv_msg.msg) {
-					int retval = -1;
 					int echo_off = (0x1 == (re.flags & 0x1));
 
 					conv_msg.msg_style =
@@ -514,6 +509,9 @@ int pam_sm_setcred(pam_handle_t * pamh, int flags, int argc, const char **argv) 
 
 	int ctrl = _pam_parse(argc, argv);
 
+	pamh = pamh;
+	flags = flags;				/* unused */
+
 	if (ctrl & PAM_TAC_DEBUG)
 		syslog(LOG_DEBUG, "%s: called (pam_tacplus v%u.%u.%u)", __FUNCTION__,
 				PAM_TAC_VMAJ, PAM_TAC_VMIN, PAM_TAC_VPAT);
@@ -536,6 +534,8 @@ int pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc,
 	struct areply arep;
 	struct tac_attrib *attr = NULL;
 	int tac_fd;
+
+	flags = flags;				/* unused */
 
 	user = tty = r_addr = NULL;
 	memset(&arep, 0, sizeof(arep));
@@ -704,6 +704,8 @@ int pam_sm_open_session(pam_handle_t * pamh, int flags, int argc,
 #else
 	task_id=(short int) magic();
 #endif
+	flags = flags;				/* unused */
+
 	return _pam_account(pamh, argc, argv, TAC_PLUS_ACCT_FLAG_START, NULL);
 } /* pam_sm_open_session */
 
@@ -714,6 +716,8 @@ int pam_sm_open_session(pam_handle_t * pamh, int flags, int argc,
 PAM_EXTERN
 int pam_sm_close_session(pam_handle_t * pamh, int flags, int argc,
 		const char **argv) {
+
+	flags = flags;				/* unused */
 
 	return _pam_account(pamh, argc, argv, TAC_PLUS_ACCT_FLAG_STOP, NULL);
 } /* pam_sm_close_session */
@@ -825,8 +829,6 @@ int pam_sm_chauthtok(pam_handle_t * pamh, int flags, int argc,
 							"tacacs status: TAC_PLUS_AUTHEN_STATUS_PASS");
 
 				if (NULL != conv_msg.msg) {
-					int retval = -1;
-
 					conv_msg.msg_style = PAM_TEXT_INFO;
 					retval = converse(pamh, 1, &conv_msg, &resp);
 					if (PAM_SUCCESS == retval) {
@@ -856,8 +858,6 @@ int pam_sm_chauthtok(pam_handle_t * pamh, int flags, int argc,
 							"tacacs status: TAC_PLUS_AUTHEN_STATUS_FAIL");
 
 				if (NULL != conv_msg.msg) {
-					int retval = -1;
-
 					conv_msg.msg_style = PAM_ERROR_MSG;
 					retval = converse(pamh, 1, &conv_msg, &resp);
 					if (PAM_SUCCESS == retval) {
@@ -883,7 +883,6 @@ int pam_sm_chauthtok(pam_handle_t * pamh, int flags, int argc,
 							"tacacs status: TAC_PLUS_AUTHEN_STATUS_GETDATA");
 
 				if (NULL != conv_msg.msg) {
-					int retval = -1;
 					int echo_off = (0x1 == (re.flags & 0x1));
 
 					conv_msg.msg_style =

--- a/support.c
+++ b/support.c
@@ -106,11 +106,13 @@ int converse(pam_handle_t * pamh, int nargs, const struct pam_message *message,
 }
 
 /* stolen from pam_stress */
-int tacacs_get_password (pam_handle_t * pamh, int flags
-    ,int ctrl, char **password) {
+int tacacs_get_password (pam_handle_t * pamh, int flags,
+    int ctrl, char **password) {
 
     const void *pam_pass;
     char *pass = NULL;
+
+    flags = flags;				/* unused */
 
     if (ctrl & PAM_TAC_DEBUG)
         syslog (LOG_DEBUG, "%s: called", __FUNCTION__);
@@ -197,7 +199,7 @@ int _pam_parse (int argc, const char **argv) {
         } else if (!strncmp (*argv, "prompt=", 7)) { /* authentication */
             xstrcpy (tac_prompt, *argv + 7, sizeof(tac_prompt));
             /* Replace _ with space */
-            int chr;
+            unsigned chr;
             for (chr = 0; chr < strlen(tac_prompt); chr++) {
                 if (tac_prompt[chr] == '_') {
                     tac_prompt[chr] = ' ';

--- a/tacc.c
+++ b/tacc.c
@@ -123,7 +123,6 @@ int main(int argc, char **argv) {
 #ifndef USE_SYSTEM
 	pid_t pid;
 #endif
-	char *msg;
 	struct areply arep;
 
 	/* options */
@@ -434,6 +433,8 @@ int main(int argc, char **argv) {
 }
 
 void sighandler(int sig) {
+	sig = sig;				/* unused */
+
 	TACDEBUG((LOG_DEBUG, "caught signal %d", sig));
 }
 
@@ -441,7 +442,6 @@ void authenticate(const struct addrinfo *tac_server, const char *tac_secret,
 		const char *user, const char *pass, const char *tty,
 		const char *remote_addr) {
 	int tac_fd;
-	char *msg;
 	int ret;
 	struct areply arep;
 
@@ -549,6 +549,7 @@ unsigned long getservername(char *serv) {
 }
 
 void timeout_handler(int signum) {
-	syslog(LOG_ERR, "timeout reading password from user %s", user);
+	signum = signum;			/* unused */
 
+	syslog(LOG_ERR, "timeout reading password from user %s", user);
 }


### PR DESCRIPTION
And fix subsequent warnings caused by:

- shadowed variables (i.e. variables existing in nested scopes);

- signed vs. unsigned comparisons

- string pointers and buffers being unsigned which don't need to be;

- unnecessary casts;

- unused variables (or only used when debugging is enabled);