### PR TITLE
Various cryptography improvements

### DIFF
--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -147,7 +147,6 @@ int tac_cont_send_seq(int, char *, int);
 #define tac_cont_send(fd, pass) tac_cont_send_seq((fd), (pass), 3)
 HDR *_tac_req_header(u_char, int);
 void _tac_crypt(u_char *, const HDR *);
-u_char *_tac_md5_pad(const HDR *);
 void tac_add_attrib(struct tac_attrib **, char *, char *);
 void tac_free_attrib(struct tac_attrib **);
 char *tac_acct_flag2str(int);

--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -146,8 +146,8 @@ int tac_authen_read(int, struct areply *);
 int tac_cont_send_seq(int, char *, int);
 #define tac_cont_send(fd, pass) tac_cont_send_seq((fd), (pass), 3)
 HDR *_tac_req_header(u_char, int);
-void _tac_crypt(u_char *, HDR *, int);
-u_char *_tac_md5_pad(int, HDR *);
+void _tac_crypt(u_char *, const HDR *);
+u_char *_tac_md5_pad(const HDR *);
 void tac_add_attrib(struct tac_attrib **, char *, char *);
 void tac_free_attrib(struct tac_attrib **);
 char *tac_acct_flag2str(int);

--- a/libtac/lib/acct_r.c
+++ b/libtac/lib/acct_r.c
@@ -110,7 +110,7 @@ int tac_acct_read(int fd, struct areply *re) {
     }
 
     /* decrypt the body */
-    _tac_crypt((u_char *) tb, &th, ulen_from_header);
+    _tac_crypt((u_char *) tb, &th);
 
     /* Convert network byte order to host byte order */
     tb->msg_len  = ntohs(tb->msg_len);

--- a/libtac/lib/acct_s.c
+++ b/libtac/lib/acct_s.c
@@ -162,7 +162,7 @@ int tac_acct_send(int fd, int type, const char *user, char *tty,
     }
         
     /* encrypt packet body  */
-    _tac_crypt(pkt, th, pkt_len);
+    _tac_crypt(pkt, th);
 
     /* write body */
     w=write(fd, pkt, pkt_len);

--- a/libtac/lib/authen_r.c
+++ b/libtac/lib/authen_r.c
@@ -106,7 +106,7 @@ int tac_authen_read(int fd, struct areply *re) {
 	}
 
 	/* decrypt the body */
-	_tac_crypt((u_char *) tb, &th, len_from_header);
+	_tac_crypt((u_char *) tb, &th);
 
 	/* Convert network byte order to host byte order */
 	tb->msg_len = ntohs(tb->msg_len);

--- a/libtac/lib/authen_s.c
+++ b/libtac/lib/authen_s.c
@@ -169,7 +169,7 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 	}
 
 	/* encrypt the body */
-	_tac_crypt(pkt, th, bodylength);
+	_tac_crypt(pkt, th);
 
 	w = write(fd, pkt, pkt_len);
 	if (w < 0 || w < pkt_len) {

--- a/libtac/lib/author_r.c
+++ b/libtac/lib/author_r.c
@@ -113,7 +113,7 @@ int tac_author_read(int fd, struct areply *re) {
 	}
 
 	/* decrypt the body */
-	_tac_crypt((u_char *) tb, &th, len_from_header);
+	_tac_crypt((u_char *) tb, &th);
 
 	/* Convert network byte order to host byte order */
 	tb->msg_len = ntohs(tb->msg_len);

--- a/libtac/lib/author_s.c
+++ b/libtac/lib/author_s.c
@@ -151,7 +151,7 @@ int tac_author_send(int fd, const char *user, char *tty, char *r_addr,
 	}
 
 	/* encrypt packet body  */
-	_tac_crypt(pkt, th, pkt_len);
+	_tac_crypt(pkt, th);
 
 	/* write body */
 	w = write(fd, pkt, pkt_len);

--- a/libtac/lib/cont_s.c
+++ b/libtac/lib/cont_s.c
@@ -92,7 +92,7 @@ int tac_cont_send_seq(int fd, char *pass, int seq) {
 	}
 
 	/* encrypt the body */
-	_tac_crypt(pkt, th, bodylength);
+	_tac_crypt(pkt, th);
 
 	w = write(fd, pkt, pkt_len);
 	if (w < 0 || w < pkt_len) {

--- a/libtac/lib/md5.c
+++ b/libtac/lib/md5.c
@@ -97,7 +97,7 @@ void MD5Init (MD5_CTX *mdContext) {
  account for the presence of each of the characters inBuf[0..inLen-1]
  in the message whose digest is being computed.
  */
-void MD5Update ( MD5_CTX *mdContext, unsigned char *inBuf,
+void MD5Update ( MD5_CTX *mdContext, const unsigned char *inBuf,
 		unsigned int inLen) {
 
 	UINT4 in[16];

--- a/libtac/lib/md5.h
+++ b/libtac/lib/md5.h
@@ -35,7 +35,7 @@ typedef struct {
 
 __BEGIN_DECLS
 void MD5Init __P((MD5_CTX*));
-void MD5Update __P((MD5_CTX*, unsigned char*, UINT4));
+void MD5Update __P((MD5_CTX*, const unsigned char*, UINT4));
 void MD5Final __P((unsigned char[], MD5_CTX*));
 __END_DECLS
 


### PR DESCRIPTION
First, cryptography is expensive enough as it is without having to
do unnecessary data marshalling, etc.  Don't allocate bufers you
don't have to, nor copy any data you don't have to.  Also, malloc'ing
can potentially cause a system call (sbrk()) if you run out of heap
space, which also makes encryption potentially blocking and that's
never a good thing.

Second, don't pass in redundant parameters (like message length)
when this is already derivable from the header, which is already
a parameter.

Third, modularize computing CHAP digests: it makes it easier to
read, debug, and maintain.

Fourth, don't compute the pad all at once when you only need it
16 bytes at a time.

Fifth, MD5Update doesn't modify the data it is digesting, so make
that parameter be 'const'.