### PR TITLE
Make TACDEBUG and TACSYSLOG into varargs macros

### DIFF
--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -45,19 +45,31 @@ extern "C" {
 #include "tacplus.h"
 
 #if defined(DEBUGTAC) && !defined(TACDEBUG)
-#define TACDEBUG(x) syslog x;
+# ifdef __GNUC__
+#define TACDEBUG(level, fmt, ...) syslog(level, fmt, ## __VA_ARGS__)
+# else
+#define TACDEBUG(level, fmt, ...) syslog(level, fmt, __VA_ARGS__)
+# endif
 #else
-//#define TACDEBUG(x) syslog x;
-#define TACDEBUG(x)
+#define TACDEBUG(level, fmt, ...) (void)0
 #endif
 
-#define TACSYSLOG(x) syslog x;
+#ifdef __GNUC__
+#define TACSYSLOG(level, fmt, ...) syslog(level, fmt, ## __VA_ARGS__)
+#else
+#define TACSYSLOG(level, fmt, ...) syslog(level, fmt, __VA_ARGS__)
+#endif
 
 #if defined(TACDEBUG_AT_RUNTIME)
 #undef TACDEBUG
 #undef TACSYSLOG
-#define TACDEBUG(x) if (tac_debug_enable) (void)logmsg x;
-#define TACSYSLOG(x) (void)logmsg x;
+# ifdef __GNUC__
+#define TACDEBUG(level, fmt, ...) do { if (tac_debug_enable) (void)logmsg(level, fmt, ## __VA_ARGS__); } while (0)
+#define TACSYSLOG(level, fmt, ...) (void)logmsg(level, fmt, ## __VA_ARGS__)
+# else
+#define TACDEBUG(level, fmt, ...) do { if (tac_debug_enable) (void)logmsg(level, fmt, __VA_ARGS__); } while (0)
+#define TACSYSLOG(level, fmt, ...) (void)logmsg(level, fmt, __VA_ARGS__)
+# endif
 extern int logmsg __P((int, const char*, ...));
 #endif
 

--- a/libtac/lib/acct_r.c
+++ b/libtac/lib/acct_r.c
@@ -44,8 +44,8 @@ int tac_acct_read(int fd, struct areply *re) {
 
     if (tac_readtimeout_enable &&
         tac_read_wait(fd,tac_timeout*1000, TAC_PLUS_HDR_SIZE,&timeleft) < 0 ) {
-        TACSYSLOG((LOG_ERR,\
-            "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout))
+        TACSYSLOG(LOG_ERR,\
+            "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout);
         re->msg = xstrdup(acct_syserr_msg);
         re->status = LIBTAC_STATUS_READ_TIMEOUT;
         free(tb);
@@ -54,9 +54,9 @@ int tac_acct_read(int fd, struct areply *re) {
 
     spacket_read = read(fd, &th, TAC_PLUS_HDR_SIZE);
     if(spacket_read  < TAC_PLUS_HDR_SIZE) {
-        TACSYSLOG((LOG_ERR,\
+        TACSYSLOG(LOG_ERR,\
             "%s: short reply header, read %zd of %u expected: %m", __FUNCTION__,\
-            spacket_read, TAC_PLUS_HDR_SIZE))
+            spacket_read, TAC_PLUS_HDR_SIZE);
         re->msg = xstrdup(acct_syserr_msg);
         re->status = LIBTAC_STATUS_SHORT_HDR;
         free(tb);
@@ -69,17 +69,17 @@ int tac_acct_read(int fd, struct areply *re) {
         re->msg = xstrdup(msg);
         re->status = LIBTAC_STATUS_PROTOCOL_ERR;
         free(tb);
-        TACDEBUG((LOG_DEBUG, "%s: exit status=%d, status message \"%s\"",\
-            __FUNCTION__, re->status, re->msg != NULL ? re->msg : ""))
+        TACDEBUG(LOG_DEBUG, "%s: exit status=%d, status message \"%s\"",\
+            __FUNCTION__, re->status, re->msg != NULL ? re->msg : "");
         return re->status;
     }
 
     ulen_from_header = ntohl(th.datalength);
     if (ulen_from_header > TAC_PLUS_MAX_PACKET_SIZE) {
-        TACSYSLOG((LOG_ERR,\
+        TACSYSLOG(LOG_ERR,\
             "%s: length declared in the packet %zu exceeds max allowed packet size %d",\
             __FUNCTION__,\
-            ulen_from_header, TAC_PLUS_MAX_PACKET_SIZE))
+            ulen_from_header, TAC_PLUS_MAX_PACKET_SIZE);
         re->status=LIBTAC_STATUS_SHORT_HDR;
         free(tb);
         return re->status;
@@ -89,8 +89,8 @@ int tac_acct_read(int fd, struct areply *re) {
     /* read reply packet body */
     if (tac_readtimeout_enable &&
         tac_read_wait(fd,timeleft,ulen_from_header,NULL) < 0 ) {
-        TACSYSLOG((LOG_ERR,\
-            "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout))
+        TACSYSLOG(LOG_ERR,\
+            "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout);
         re->msg = xstrdup(acct_syserr_msg);
         re->status = LIBTAC_STATUS_READ_TIMEOUT;
         free(tb);
@@ -99,10 +99,10 @@ int tac_acct_read(int fd, struct areply *re) {
 
     spacket_read = read(fd, tb, ulen_from_header);
     if(spacket_read < (ssize_t) ulen_from_header) {
-        TACSYSLOG((LOG_ERR,\
+        TACSYSLOG(LOG_ERR,\
             "%s: short reply body, read %zd of %zu: %m",\
             __FUNCTION__,\
-			spacket_read, ulen_from_header))
+			spacket_read, ulen_from_header);
         re->msg = xstrdup(acct_syserr_msg);
         re->status = LIBTAC_STATUS_SHORT_BODY;
         free(tb);
@@ -121,9 +121,9 @@ int tac_acct_read(int fd, struct areply *re) {
         sizeof(tb->status) + tb->msg_len + tb->data_len;
 
     if(ulen_from_header != len_from_body) {
-        TACSYSLOG((LOG_ERR,\
+        TACSYSLOG(LOG_ERR,\
             "%s: inconsistent reply body, incorrect key?",\
-            __FUNCTION__))
+            __FUNCTION__);
         re->msg = xstrdup(acct_syserr_msg);
         re->status = LIBTAC_STATUS_PROTOCOL_ERR;
         free(tb);
@@ -140,15 +140,15 @@ int tac_acct_read(int fd, struct areply *re) {
 
     /* server logged our request successfully */
     if (tb->status == TAC_PLUS_ACCT_STATUS_SUCCESS) {
-        TACDEBUG((LOG_DEBUG, "%s: accounted ok", __FUNCTION__))
+        TACDEBUG(LOG_DEBUG, "%s: accounted ok", __FUNCTION__);
         if (!re->msg) re->msg = xstrdup(acct_ok_msg);
         re->status = tb->status;
         free(tb);
         return re->status;
     }
 
-    TACDEBUG((LOG_DEBUG, "%s: accounting failed, server reply status=%d",\
-        __FUNCTION__, tb->status))
+    TACDEBUG(LOG_DEBUG, "%s: accounting failed, server reply status=%d",\
+        __FUNCTION__, tb->status);
     switch(tb->status) {
         case TAC_PLUS_ACCT_STATUS_FOLLOW:
             re->status = tb->status;

--- a/libtac/lib/acct_s.c
+++ b/libtac/lib/acct_s.c
@@ -66,10 +66,10 @@ int tac_acct_send(int fd, int type, const char *user, char *tty,
     th->version=TAC_PLUS_VER_0;
     th->encryption=tac_encryption ? TAC_PLUS_ENCRYPTED_FLAG : TAC_PLUS_UNENCRYPTED_FLAG;
 
-    TACDEBUG((LOG_DEBUG, "%s: user '%s', tty '%s', rem_addr '%s', encrypt: %s, type: %s", \
+    TACDEBUG(LOG_DEBUG, "%s: user '%s', tty '%s', rem_addr '%s', encrypt: %s, type: %s", \
         __FUNCTION__, user, tty, r_addr, \
         (tac_encryption) ? "yes" : "no", \
-        tac_acct_flag2str(type)))
+        tac_acct_flag2str(type));
         
     user_len=(u_char) strlen(user);
     port_len=(u_char) strlen(tty);
@@ -154,8 +154,8 @@ int tac_acct_send(int fd, int type, const char *user, char *tty,
     w = write(fd, th, TAC_PLUS_HDR_SIZE);
 
     if(w < TAC_PLUS_HDR_SIZE) {
-        TACSYSLOG((LOG_ERR, "%s: short write on header, wrote %d of %d: %m",\
-            __FUNCTION__, w, TAC_PLUS_HDR_SIZE))
+        TACSYSLOG(LOG_ERR, "%s: short write on header, wrote %d of %d: %m",\
+            __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
         free(pkt);
         free(th);
         return LIBTAC_STATUS_WRITE_ERR;
@@ -167,13 +167,13 @@ int tac_acct_send(int fd, int type, const char *user, char *tty,
     /* write body */
     w=write(fd, pkt, pkt_len);
     if(w < pkt_len) {
-        TACSYSLOG((LOG_ERR, "%s: short write on body, wrote %d of %d: %m",\
-            __FUNCTION__, w, pkt_len))
+        TACSYSLOG(LOG_ERR, "%s: short write on body, wrote %d of %d: %m",\
+            __FUNCTION__, w, pkt_len);
         ret = LIBTAC_STATUS_WRITE_ERR;
     }
 
     free(pkt);
     free(th);
-    TACDEBUG((LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret))
+    TACDEBUG(LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret);
     return ret;
 }

--- a/libtac/lib/attrib.c
+++ b/libtac/lib/attrib.c
@@ -41,9 +41,9 @@ void tac_add_attrib_pair(struct tac_attrib **attr, char *name, char sep, char *v
     total_len = l1 + l2 + 1; /* "name" + "=" + "value" */
 
     if (total_len > 255) {
-        TACSYSLOG((LOG_WARNING,\
+        TACSYSLOG(LOG_WARNING,\
             "%s: attribute `%s' total length exceeds 255 characters, skipping",\
-            __FUNCTION__, name))
+            __FUNCTION__, name);
         return;
     }
 

--- a/libtac/lib/authen_r.c
+++ b/libtac/lib/authen_r.c
@@ -50,7 +50,7 @@ int tac_authen_read(int fd, struct areply *re) {
 			&& tac_read_wait(fd, tac_timeout * 1000, TAC_PLUS_HDR_SIZE,
 					&timeleft) < 0) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout))
+				LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout);
 		re->status = LIBTAC_STATUS_READ_TIMEOUT;
 		free(tb);
 		return re->status;
@@ -58,7 +58,7 @@ int tac_authen_read(int fd, struct areply *re) {
 	spacket_read = read(fd, &th, TAC_PLUS_HDR_SIZE);
 	if (spacket_read < TAC_PLUS_HDR_SIZE) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short reply header, read %zd of %d: %m", __FUNCTION__, spacket_read, TAC_PLUS_HDR_SIZE))
+				LOG_ERR, "%s: short reply header, read %zd of %d: %m", __FUNCTION__, spacket_read, TAC_PLUS_HDR_SIZE);
 		re->status = LIBTAC_STATUS_SHORT_HDR;
 		free(tb);
 		return re->status;
@@ -78,7 +78,7 @@ int tac_authen_read(int fd, struct areply *re) {
 	len_from_header = ntohl(th.datalength);
 	if (len_from_header > TAC_PLUS_MAX_PACKET_SIZE) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: length declared in the packet %zu exceeds max packet size %d", __FUNCTION__, len_from_header, TAC_PLUS_MAX_PACKET_SIZE))
+				LOG_ERR, "%s: length declared in the packet %zu exceeds max packet size %d", __FUNCTION__, len_from_header, TAC_PLUS_MAX_PACKET_SIZE);
 		re->status = LIBTAC_STATUS_PROTOCOL_ERR;
 		free(tb);
 		return re->status;
@@ -89,7 +89,7 @@ int tac_authen_read(int fd, struct areply *re) {
 	if (tac_readtimeout_enable
 			&& tac_read_wait(fd, timeleft, len_from_header, NULL) < 0) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout))
+				LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout);
 		re->msg = xstrdup(authen_syserr_msg);
 		re->status = LIBTAC_STATUS_READ_TIMEOUT;
 		free(tb);
@@ -98,7 +98,7 @@ int tac_authen_read(int fd, struct areply *re) {
 	spacket_read = read(fd, tb, len_from_header);
 	if (spacket_read < (ssize_t) len_from_header) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short reply body, read %zd of %zu: %m", __FUNCTION__, spacket_read, len_from_header))
+				LOG_ERR, "%s: short reply body, read %zd of %zu: %m", __FUNCTION__, spacket_read, len_from_header);
 		re->msg = xstrdup(authen_syserr_msg);
 		re->status = LIBTAC_STATUS_SHORT_BODY;
 		free(tb);
@@ -118,7 +118,7 @@ int tac_authen_read(int fd, struct areply *re) {
 
 	if (len_from_header != len_from_body) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: inconsistent reply body, incorrect key?", __FUNCTION__))
+				LOG_ERR, "%s: inconsistent reply body, incorrect key?", __FUNCTION__);
 		re->msg = xstrdup(protocol_err_msg);
 		re->status = LIBTAC_STATUS_PROTOCOL_ERR;
 		free(tb);
@@ -138,14 +138,14 @@ int tac_authen_read(int fd, struct areply *re) {
 
 	/* server authenticated username and password successfully */
 	if (re->status == TAC_PLUS_AUTHEN_STATUS_PASS) {
-		TACDEBUG((LOG_DEBUG, "%s: authentication ok", __FUNCTION__))
+		TACDEBUG(LOG_DEBUG, "%s: authentication ok", __FUNCTION__);
 		free(tb);
 		return re->status;
 	}
 
 	/* server ask for continue packet with password */
 	if (re->status == TAC_PLUS_AUTHEN_STATUS_GETPASS) {
-		TACDEBUG((LOG_DEBUG, "%s: continue packet with password needed", __FUNCTION__))
+		TACDEBUG(LOG_DEBUG, "%s: continue packet with password needed", __FUNCTION__);
 		free(tb);
 		return re->status;
 	}
@@ -154,14 +154,14 @@ int tac_authen_read(int fd, struct areply *re) {
 	if (re->status == TAC_PLUS_AUTHEN_STATUS_GETDATA) {
 		re->flags = tb->flags;
 
-		TACDEBUG((LOG_DEBUG, "%s: continue packet with data request: msg=%.*s",
-						__func__, tb->msg_len, (char*)tb + sizeof(struct authen_reply)))
+		TACDEBUG(LOG_DEBUG, "%s: continue packet with data request: msg=%.*s",
+						__func__, tb->msg_len, (char*)tb + sizeof(struct authen_reply));
 		free(tb);
 		return re->status;
 	}
 
-	TACDEBUG((LOG_DEBUG, "%s: authentication failed, server reply status=%d",
-					__FUNCTION__, r))
+	TACDEBUG(LOG_DEBUG, "%s: authentication failed, server reply status=%d",
+					__FUNCTION__, r);
 
 	free(tb);
 	return re->status;

--- a/libtac/lib/authen_s.c
+++ b/libtac/lib/authen_s.c
@@ -69,9 +69,9 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 			tac_encryption ?
 					TAC_PLUS_ENCRYPTED_FLAG : TAC_PLUS_UNENCRYPTED_FLAG;
 
-	TACDEBUG((LOG_DEBUG, "%s: user '%s', tty '%s', rem_addr '%s', encrypt: %s",
+	TACDEBUG(LOG_DEBUG, "%s: user '%s', tty '%s', rem_addr '%s', encrypt: %s",
 					__FUNCTION__, user, tty, r_addr,
-					(tac_encryption) ? "yes" : "no"))
+					(tac_encryption) ? "yes" : "no");
 
 	if (!strcmp(tac_login, "chap")) {
 		chal_len = strlen(chal);
@@ -136,7 +136,7 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 	w = write(fd, th, TAC_PLUS_HDR_SIZE);
 	if (w < 0 || w < TAC_PLUS_HDR_SIZE) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short write on header, wrote %d of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE))
+				LOG_ERR, "%s: short write on header, wrote %d of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
 		free(token);
 		free(pkt);
 		free(th);
@@ -161,7 +161,7 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 	/* pkt_len == bodylength ? */
 	if (pkt_len != bodylength) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: bodylength %d != pkt_len %d", __FUNCTION__, bodylength, pkt_len))
+				LOG_ERR, "%s: bodylength %d != pkt_len %d", __FUNCTION__, bodylength, pkt_len);
 		free(token);
 		free(pkt);
 		free(th);
@@ -174,14 +174,14 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 	w = write(fd, pkt, pkt_len);
 	if (w < 0 || w < pkt_len) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short write on body, wrote %d of %d: %m", __FUNCTION__, w, pkt_len))
+				LOG_ERR, "%s: short write on body, wrote %d of %d: %m", __FUNCTION__, w, pkt_len);
 		ret = LIBTAC_STATUS_WRITE_ERR;
 	}
 
 	free(token);
 	free(pkt);
 	free(th);
-	TACDEBUG((LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret))
+	TACDEBUG(LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret);
 	return ret;
 } /* tac_authen_send */
 

--- a/libtac/lib/author_r.c
+++ b/libtac/lib/author_r.c
@@ -55,7 +55,7 @@ int tac_author_read(int fd, struct areply *re) {
 					&timeleft) < 0) {
 
 		TACSYSLOG(
-				(LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout))
+				LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout);
 		re->msg = xstrdup(author_syserr_msg);
 		re->status = LIBTAC_STATUS_READ_TIMEOUT;
 		free(tb);
@@ -65,7 +65,7 @@ int tac_author_read(int fd, struct areply *re) {
 	packet_read = read(fd, &th, TAC_PLUS_HDR_SIZE);
 	if (packet_read < TAC_PLUS_HDR_SIZE) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short reply header, read %zd of %d: %m", __FUNCTION__, packet_read, TAC_PLUS_HDR_SIZE))
+				LOG_ERR, "%s: short reply header, read %zd of %d: %m", __FUNCTION__, packet_read, TAC_PLUS_HDR_SIZE);
 		re->msg = xstrdup(author_syserr_msg);
 		re->status = LIBTAC_STATUS_SHORT_HDR;
 		free(tb);
@@ -85,7 +85,7 @@ int tac_author_read(int fd, struct areply *re) {
 	len_from_header = ntohl(th.datalength);
 	if (len_from_header > TAC_PLUS_MAX_PACKET_SIZE) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: length declared in the packet %zu exceeds max packet size %d", __FUNCTION__, len_from_header, TAC_PLUS_MAX_PACKET_SIZE))
+				LOG_ERR, "%s: length declared in the packet %zu exceeds max packet size %d", __FUNCTION__, len_from_header, TAC_PLUS_MAX_PACKET_SIZE);
 		re->status = LIBTAC_STATUS_PROTOCOL_ERR;
 		free(tb);
 		return re->status;
@@ -97,7 +97,7 @@ int tac_author_read(int fd, struct areply *re) {
 			&& tac_read_wait(fd, timeleft, len_from_header, NULL) < 0) {
 
 		TACSYSLOG(
-				(LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout))
+				LOG_ERR, "%s: reply timeout after %u secs", __FUNCTION__, tac_timeout);
 		re->msg = xstrdup(author_syserr_msg);
 		re->status = LIBTAC_STATUS_READ_TIMEOUT;
 		free(tb);
@@ -106,7 +106,7 @@ int tac_author_read(int fd, struct areply *re) {
 	packet_read = read(fd, tb, len_from_header);
 	if (packet_read < (ssize_t) len_from_header) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short reply body, read %zd of %zu", __FUNCTION__, packet_read, len_from_header))
+				LOG_ERR, "%s: short reply body, read %zd of %zu", __FUNCTION__, packet_read, len_from_header);
 		re->msg = xstrdup(author_syserr_msg);
 		re->status = LIBTAC_STATUS_SHORT_BODY;
 		free(tb);
@@ -135,7 +135,7 @@ int tac_author_read(int fd, struct areply *re) {
 		if ((ssize_t) len_from_body > packet_read
 				|| ((void *) pktp - (void *) tb) > packet_read) {
 			TACSYSLOG(
-					(LOG_ERR, "%s: arguments supplied in packet seem to exceed its size", __FUNCTION__))
+					LOG_ERR, "%s: arguments supplied in packet seem to exceed its size", __FUNCTION__);
 			re->msg = xstrdup(protocol_err_msg);
 			re->status = LIBTAC_STATUS_PROTOCOL_ERR;
 			free(tb);
@@ -148,7 +148,7 @@ int tac_author_read(int fd, struct areply *re) {
 
 	if (len_from_header != len_from_body) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: inconsistent reply body, incorrect key?", __FUNCTION__))
+				LOG_ERR, "%s: inconsistent reply body, incorrect key?", __FUNCTION__);
 		re->msg = xstrdup(protocol_err_msg);
 		re->status = LIBTAC_STATUS_PROTOCOL_ERR;
 		free(tb);
@@ -174,12 +174,12 @@ int tac_author_read(int fd, struct areply *re) {
 						+ (tb->arg_cnt) * sizeof(u_char) + tb->msg_len, smsg,
 				tb->data_len);
 		smsg[(int) tb->data_len] = '\0';
-		TACSYSLOG((LOG_ERR, "%s: reply message: %s", __FUNCTION__,smsg))
+		TACSYSLOG(LOG_ERR, "%s: reply message: %s", __FUNCTION__, smsg);
 		free(smsg);
 	}
 
-	TACDEBUG((LOG_DEBUG, "%s: authorization reply status=%d",
-					__FUNCTION__, tb->status));
+	TACDEBUG(LOG_DEBUG, "%s: authorization reply status=%d",
+					__FUNCTION__, tb->status);
 
 	/* prepare status */
 	switch (tb->status) {
@@ -200,7 +200,7 @@ int tac_author_read(int fd, struct areply *re) {
 		pktp = (u_char *) tb + TAC_AUTHOR_REPLY_FIXED_FIELDS_SIZE;
 		argp = pktp + (tb->arg_cnt * sizeof(u_char)) + tb->msg_len
 				+ tb->data_len;
-		TACSYSLOG((LOG_DEBUG, "Args cnt %d", tb->arg_cnt));
+		TACSYSLOG(LOG_DEBUG, "Args cnt %d", tb->arg_cnt);
 		/* argp points to current argument string
 		 pktp points to current argument length */
 		for (r = 0; r < tb->arg_cnt && r < TAC_PLUS_MAX_ARGCOUNT;
@@ -218,7 +218,7 @@ int tac_author_read(int fd, struct areply *re) {
 			}
 			if (sep == NULL) {
 				TACSYSLOG(
-						(LOG_WARNING, "AUTHOR_STATUS_PASS_ADD/REPL: av pair does not contain a separator: %s", buff))
+						LOG_WARNING, "AUTHOR_STATUS_PASS_ADD/REPL: av pair does not contain a separator: %s", buff);
 				/* now buff points to attribute name, make value ""
 				 treat as "name=" */
 				value = "";
@@ -229,7 +229,7 @@ int tac_author_read(int fd, struct areply *re) {
 				/* now buff points to attribute name,
 				 value to the attribute value */
 			}
-			TACSYSLOG((LOG_DEBUG, "Adding buf/value pair (%s,%s)", buff, value));
+			TACSYSLOG(LOG_DEBUG, "Adding buf/value pair (%s,%s)", buff, value);
 			tac_add_attrib_pair(&re->attr, buff, sepchar, value);
 			argp += *pktp;
 			pktp++;

--- a/libtac/lib/author_s.c
+++ b/libtac/lib/author_s.c
@@ -55,9 +55,9 @@ int tac_author_send(int fd, const char *user, char *tty, char *r_addr,
 			tac_encryption ?
 					TAC_PLUS_ENCRYPTED_FLAG : TAC_PLUS_UNENCRYPTED_FLAG;
 
-	TACDEBUG((LOG_DEBUG, "%s: user '%s', tty '%s', rem_addr '%s', encrypt: %s",
+	TACDEBUG(LOG_DEBUG, "%s: user '%s', tty '%s', rem_addr '%s', encrypt: %s",
 					__FUNCTION__, user,
-					tty, r_addr, tac_encryption ? "yes" : "no"))
+					tty, r_addr, tac_encryption ? "yes" : "no");
 
 	user_len = (u_char) strlen(user);
 	port_len = (u_char) strlen(tty);
@@ -144,7 +144,7 @@ int tac_author_send(int fd, const char *user, char *tty, char *r_addr,
 
 	if (w < TAC_PLUS_HDR_SIZE) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short write on header, wrote %d of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE))
+				LOG_ERR, "%s: short write on header, wrote %d of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
 		free(pkt);
 		free(th);
 		return LIBTAC_STATUS_WRITE_ERR;
@@ -157,12 +157,12 @@ int tac_author_send(int fd, const char *user, char *tty, char *r_addr,
 	w = write(fd, pkt, pkt_len);
 	if (w < pkt_len) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short write on body, wrote %d of %d: %m", __FUNCTION__, w, pkt_len))
+				LOG_ERR, "%s: short write on body, wrote %d of %d: %m", __FUNCTION__, w, pkt_len);
 		ret = LIBTAC_STATUS_WRITE_ERR;
 	}
 
 	free(pkt);
 	free(th);
-	TACDEBUG((LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret))
+	TACDEBUG(LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret);
 	return ret;
 }

--- a/libtac/lib/connect.c
+++ b/libtac/lib/connect.c
@@ -47,7 +47,7 @@ int tac_connect(struct addrinfo **server, char **key, int servers) {
     int fd=-1;
 
     if(servers == 0 || server == NULL) {
-        TACSYSLOG((LOG_ERR, "%s: no TACACS+ servers defined", __FUNCTION__))
+        TACSYSLOG(LOG_ERR, "%s: no TACACS+ servers defined", __FUNCTION__);
     } else {
         for ( tries = 0; tries < servers; tries++ ) {   
             if((fd=tac_connect_single(server[tries], key[tries], NULL, tac_timeout)) >= 0 ) {
@@ -58,7 +58,7 @@ int tac_connect(struct addrinfo **server, char **key, int servers) {
     }
 
     /* all attempts failed if fd is still < 0 */
-    TACDEBUG((LOG_DEBUG, "%s: exit status=%d",__FUNCTION__, fd))
+    TACDEBUG(LOG_DEBUG, "%s: exit status=%d",__FUNCTION__, fd);
     return fd;
 } /* tac_connect */
 
@@ -78,7 +78,7 @@ int tac_connect_single(const struct addrinfo *server, const char *key, struct ad
     char *ip;
 
     if(server == NULL) {
-        TACSYSLOG((LOG_ERR, "%s: no TACACS+ server defined", __FUNCTION__))
+        TACSYSLOG(LOG_ERR, "%s: no TACACS+ server defined", __FUNCTION__);
         goto bomb;
     }
 
@@ -86,8 +86,8 @@ int tac_connect_single(const struct addrinfo *server, const char *key, struct ad
     ip = tac_ntop(server->ai_addr);
 
     if((fd=socket(server->ai_family, server->ai_socktype, server->ai_protocol)) < 0) {
-        TACSYSLOG((LOG_ERR,"%s: socket creation error: %s", __FUNCTION__,
-            strerror(errno)))
+        TACSYSLOG(LOG_ERR,"%s: socket creation error: %s", __FUNCTION__,
+            strerror(errno));
         goto bomb;
     }
 
@@ -96,16 +96,16 @@ int tac_connect_single(const struct addrinfo *server, const char *key, struct ad
 
     /* put socket in non blocking mode for timeout support */
     if( fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1 ) {
-        TACSYSLOG((LOG_ERR, "%s: cannot set socket non blocking",\
-            __FUNCTION__))
+        TACSYSLOG(LOG_ERR, "%s: cannot set socket non blocking",\
+            __FUNCTION__);
         goto bomb;
     }
 
     /* bind if source address got explicity defined */
     if (srcaddr) {
         if (bind(fd, srcaddr->ai_addr, srcaddr->ai_addrlen) < 0) {
-            TACSYSLOG((LOG_ERR, "%s: Failed to bind source address: %s",
-                __FUNCTION__, strerror(errno)))
+            TACSYSLOG(LOG_ERR, "%s: Failed to bind source address: %s",
+                __FUNCTION__, strerror(errno));
             goto bomb;
         }
     }
@@ -113,8 +113,8 @@ int tac_connect_single(const struct addrinfo *server, const char *key, struct ad
     rc = connect(fd, server->ai_addr, server->ai_addrlen);
     /* FIX this..for some reason errno = 0 on AIX... */
     if((rc == -1) && (errno != EINPROGRESS) && (errno != 0)) {
-        TACSYSLOG((LOG_ERR,\
-            "%s: connection to %s failed: %m", __FUNCTION__, ip))
+        TACSYSLOG(LOG_ERR,\
+            "%s: connection to %s failed: %m", __FUNCTION__, ip);
         goto bomb;
     }
 
@@ -139,28 +139,28 @@ int tac_connect_single(const struct addrinfo *server, const char *key, struct ad
 
     /* some other error or interrupt before timeout */
     if ( rc < 0 ) {
-        TACSYSLOG((LOG_ERR,\
-            "%s: connection failed with %s: %m", __FUNCTION__, ip))
+        TACSYSLOG(LOG_ERR,\
+            "%s: connection failed with %s: %m", __FUNCTION__, ip);
         goto bomb;
     }
 
     /* check with getpeername if we have a valid connection */
     len = sizeof addr;
     if(getpeername(fd, (struct sockaddr*)&addr, &len) == -1) {
-        TACSYSLOG((LOG_ERR,\
-            "%s: connection failed with %s: %m", __FUNCTION__, ip))
+        TACSYSLOG(LOG_ERR,\
+            "%s: connection failed with %s: %m", __FUNCTION__, ip);
         goto bomb;
     }
 
     /* restore flags on socket - flags was set only when fd >= 0 */
     if(fcntl(fd, F_SETFL, flags) == -1) {
-        TACSYSLOG((LOG_ERR, "%s: cannot restore socket flags: %m",\
-             __FUNCTION__)) 
+        TACSYSLOG(LOG_ERR, "%s: cannot restore socket flags: %m",\
+             __FUNCTION__);
         goto bomb;
     }
 
     /* connected ok */
-    TACDEBUG((LOG_DEBUG, "%s: connected to %s", __FUNCTION__, ip))
+    TACDEBUG(LOG_DEBUG, "%s: connected to %s", __FUNCTION__, ip);
     retval = fd;
 
     /* set current tac_secret */
@@ -174,8 +174,8 @@ bomb:
     if (retval < 0 && fd != -1)
        close(fd);
 
-    TACDEBUG((LOG_DEBUG, "%s: exit status=%d (fd=%d)",\
-        __FUNCTION__, retval < 0 ? retval:0, fd))
+    TACDEBUG(LOG_DEBUG, "%s: exit status=%d (fd=%d)",\
+        __FUNCTION__, retval < 0 ? retval:0, fd);
     return retval;
 } /* tac_connect_single */
 

--- a/libtac/lib/cont_s.c
+++ b/libtac/lib/cont_s.c
@@ -68,7 +68,7 @@ int tac_cont_send_seq(int fd, char *pass, int seq) {
 	w = write(fd, th, TAC_PLUS_HDR_SIZE);
 	if (w < 0 || w < TAC_PLUS_HDR_SIZE) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short write on header, wrote %d of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE))
+				LOG_ERR, "%s: short write on header, wrote %d of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
 		free(pkt);
 		free(th);
 		return LIBTAC_STATUS_WRITE_ERR;
@@ -85,7 +85,7 @@ int tac_cont_send_seq(int fd, char *pass, int seq) {
 	/* pkt_len == bodylength ? */
 	if (pkt_len != bodylength) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: bodylength %d != pkt_len %d", __FUNCTION__, bodylength, pkt_len))
+				LOG_ERR, "%s: bodylength %d != pkt_len %d", __FUNCTION__, bodylength, pkt_len);
 		free(pkt);
 		free(th);
 		return LIBTAC_STATUS_ASSEMBLY_ERR;
@@ -97,12 +97,12 @@ int tac_cont_send_seq(int fd, char *pass, int seq) {
 	w = write(fd, pkt, pkt_len);
 	if (w < 0 || w < pkt_len) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: short write on body, wrote %d of %d: %m", __FUNCTION__, w, pkt_len))
+				LOG_ERR, "%s: short write on body, wrote %d of %d: %m", __FUNCTION__, w, pkt_len);
 		ret = LIBTAC_STATUS_WRITE_ERR;
 	}
 
 	free(pkt);
 	free(th);
-	TACDEBUG((LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret))
+	TACDEBUG(LOG_DEBUG, "%s: exit status=%d", __FUNCTION__, ret);
 	return ret;
 } /* tac_cont_send */

--- a/libtac/lib/crypt.c
+++ b/libtac/lib/crypt.c
@@ -100,6 +100,6 @@ void _tac_crypt(u_char *buf, HDR *th, int length) {
   
         free(pad);
     } else {
-        TACSYSLOG((LOG_WARNING, "%s: using no TACACS+ encryption", __FUNCTION__))
+        TACSYSLOG(LOG_WARNING, "%s: using no TACACS+ encryption", __FUNCTION__);
     }
 }    /* _tac_crypt */

--- a/libtac/lib/hdr_check.c
+++ b/libtac/lib/hdr_check.c
@@ -31,18 +31,18 @@
  */
 char *_tac_check_header(HDR *th, int type) {
     if(th->type != type) {
-        TACSYSLOG((LOG_ERR,\
+        TACSYSLOG(LOG_ERR,\
             "%s: unrelated reply, type %d, expected %d",\
-            __FUNCTION__, th->type, type))
+            __FUNCTION__, th->type, type);
         return protocol_err_msg;
     } else if (1 == (th->seq_no % 2)) {
-        TACSYSLOG((LOG_ERR, "%s: not a reply - seq_no %d not even",\
-            __FUNCTION__, th->seq_no))
+        TACSYSLOG(LOG_ERR, "%s: not a reply - seq_no %d not even",\
+            __FUNCTION__, th->seq_no);
         return protocol_err_msg;
     } /* else if(ntohl(th->session_id) != session_id) {
-        TACSYSLOG((LOG_ERR,\
+        TACSYSLOG(LOG_ERR,\
             "%s: unrelated reply, received session_id %d != sent %d",\
-            __FUNCTION__, ntohl(th->session_id), session_id))
+            __FUNCTION__, ntohl(th->session_id), session_id);
         return protocol_err_msg;
     } */
     

--- a/libtac/lib/xalloc.c
+++ b/libtac/lib/xalloc.c
@@ -26,7 +26,7 @@ void *xcalloc(size_t nmemb, size_t size) {
 	void *val = calloc(nmemb, size);
 	if (val == 0) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: calloc(%u,%u) failed", __FUNCTION__, (unsigned) nmemb, (unsigned) size))
+				LOG_ERR, "%s: calloc(%u,%u) failed", __FUNCTION__, (unsigned) nmemb, (unsigned) size);
 		exit(1);
 	}
 	return val;
@@ -36,7 +36,7 @@ void *xrealloc(void *ptr, size_t size) {
 	void *val = realloc(ptr, size);
 	if (val == 0) {
 		TACSYSLOG(
-				(LOG_ERR, "%s: realloc(%u) failed", __FUNCTION__, (unsigned) size))
+				LOG_ERR, "%s: realloc(%u) failed", __FUNCTION__, (unsigned) size);
 		exit(1);
 	}
 	return val;
@@ -48,7 +48,7 @@ char *xstrdup(const char *s) {
 		return NULL;
 
 	if ((p = strdup(s)) == NULL) {
-		TACSYSLOG((LOG_ERR, "%s: strdup(%s) failed: %m", __FUNCTION__, s))
+		TACSYSLOG(LOG_ERR, "%s: strdup(%s) failed: %m", __FUNCTION__, s);
 		exit(1);
 	}
 	return p;
@@ -59,18 +59,18 @@ char *xstrdup(const char *s) {
  */
 char *xstrcpy(char *dst, const char *src, size_t dst_size) {
 	if (dst == NULL) {
-		TACSYSLOG((LOG_ERR, "xstrcpy(): dst == NULL"));
+		TACSYSLOG(LOG_ERR, "xstrcpy(): dst == NULL");
 		abort();
 	}
 	if (src == NULL) {
-		TACSYSLOG((LOG_ERR, "xstrcpy(): src == NULL"));
+		TACSYSLOG(LOG_ERR, "xstrcpy(): src == NULL");
 		abort();
 	}
 	if (!dst_size)
 		return NULL;
 
 	if (strlen(src) >= dst_size) {
-		TACSYSLOG((LOG_ERR, "xstrcpy(): argument too long, aborting"));
+		TACSYSLOG(LOG_ERR, "xstrcpy(): argument too long, aborting");
 		abort();
 	}
 

--- a/tacc.c
+++ b/tacc.c
@@ -435,7 +435,7 @@ int main(int argc, char **argv) {
 void sighandler(int sig) {
 	sig = sig;				/* unused */
 
-	TACDEBUG((LOG_DEBUG, "caught signal %d", sig));
+	TACDEBUG(LOG_DEBUG, "caught signal %d", sig);
 }
 
 void authenticate(const struct addrinfo *tac_server, const char *tac_secret,


### PR DESCRIPTION
Also, correct the `-DTACDEBUG_AT_RUNTIME` scenario so that `TACDEBUG()` binds correct when used in an if-body with an else following it, e.g.:

```
    if (test)
        TACDEBUG(LOG_DEBUG, "test is true");
    else
        return;
```

would previously have ended up as expanding to:

```
    if (test)
        if (tac_debug_enable) logmsg(LOG_DEBUG, "test is true");
        else
            return;
```

with the indent redone to reflect the nesting correctly.  This now expands (correctly) to:

```
    if (test)
       do { if (tac_debug_enable) logmsg(LOG_DEBUG, "test is true"); } while (0);
    else
        return;
```