### PR TITLE
Fix ASCII logins where 2 transactions are required

### DIFF
--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -155,7 +155,7 @@ char *tac_ntop(const struct sockaddr *);
 int tac_authen_send(int, const char *, const char *, const char *, const char *,
 		u_char);
 int tac_authen_read(int, struct areply *);
-int tac_cont_send_seq(int, char *, int);
+int tac_cont_send_seq(int, const char *, int);
 #define tac_cont_send(fd, pass) tac_cont_send_seq((fd), (pass), 3)
 HDR *_tac_req_header(u_char, int);
 void _tac_crypt(u_char *, const HDR *);

--- a/libtac/lib/cont_s.c
+++ b/libtac/lib/cont_s.c
@@ -35,7 +35,7 @@
  *         LIBTAC_STATUS_WRITE_TIMEOUT  (pending impl)
  *         LIBTAC_STATUS_ASSEMBLY_ERR
  */
-int tac_cont_send_seq(int fd, char *pass, int seq) {
+int tac_cont_send_seq(int fd, const char *pass, int seq) {
 	HDR *th; /* TACACS+ packet header */
 	struct authen_cont tb; /* continue body */
 	int pass_len, bodylength, w;

--- a/tacc.c
+++ b/tacc.c
@@ -463,6 +463,17 @@ void authenticate(const struct addrinfo *tac_server, const char *tac_secret,
 
 	ret = tac_authen_read(tac_fd, &arep);
 
+	if (ret == TAC_PLUS_AUTHEN_STATUS_GETPASS) {
+
+		if (tac_cont_send(tac_fd, pass) < 0) {
+			if (!quiet)
+				printf("Error sending query to TACACS+ server\n");
+			exit(EXIT_ERR);
+		}
+
+		ret = tac_authen_read(tac_fd, &arep);
+	}
+
 	if (ret != TAC_PLUS_AUTHEN_STATUS_PASS) {
 		if (!quiet)
 			printf("Authentication FAILED: %s\n", arep.msg);


### PR DESCRIPTION
`authenticate()` doesn't handle the case of an ASCII login which results in a continue request being required to complete the transaction.
