### PR TITLE
Reorg magic

### DIFF
--- a/libtac/lib/header.c
+++ b/libtac/lib/header.c
@@ -26,17 +26,7 @@
   #include "config.h"
 #endif
 
-#if defined(HAVE_OPENSSL_RAND_H) && defined(HAVE_LIBCRYPTO)
-# include <openssl/rand.h>
-#elif defined(HAVE_GETRANDOM)
-# if defined(HAVE_LINUX_RANDOM_H)
-#  include <linux/random.h>
-# elif defined(HAVE_SYS_RANDOM_H)
-#  include <sys/random.h>
-# endif
-#else
-# include "magic.h"
-#endif
+#include "magic.h"
 
 /* Miscellaneous variables that are global, because we need
  * store their values between different functions and connections.
@@ -88,16 +78,7 @@ HDR *_tac_req_header(u_char type, int cont_session) {
  
     /* make session_id from pseudo-random number */
     if (!cont_session) {
-#if defined(HAVE_OPENSSL_RAND_H) && defined(HAVE_LIBCRYPTO)
-    	// the preferred way is to use OpenSSL abstraction as we are linking it anyway for MD5
-        RAND_pseudo_bytes((unsigned char *) &session_id, sizeof(session_id));
-#elif defined(HAVE_GETRANDOM)
-        // experimental
-        getrandom((void *) &session_id, sizeof(session_id), GRND_NONBLOCK);
-#else
-        // if everything fails use the legacy code
         session_id = magic();
-#endif
     }
     th->session_id = htonl(session_id);
 

--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -23,7 +23,7 @@
 #endif
 
 /* if OpenSSL library is available this legacy code will not be compiled in */
-#if !defined(HAVE_OPENSSL_RAND_H) && !defined(HAVE_LIBCRYPTO)
+#if !(defined(HAVE_OPENSSL_RAND_H) && defined(HAVE_LIBCRYPTO))
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/libtac/lib/magic.h
+++ b/libtac/lib/magic.h
@@ -24,7 +24,6 @@
 #include "libtac.h"
 
 __BEGIN_DECLS
-void magic_init __P((void));	/* Initialize the magic number generator */
 u_int32_t magic __P((void));	/* Returns the next magic number */
 __END_DECLS
 

--- a/libtac/lib/md5.c
+++ b/libtac/lib/md5.c
@@ -23,7 +23,7 @@
 #endif
 
 /* if OpenSSL library is available this legacy code will not be compiled in */
-#if !defined(HAVE_OPENSSL_MD5_H) && !defined(HAVE_LIBCRYPTO)
+#if !(defined(HAVE_OPENSSL_MD5_H) && defined(HAVE_LIBCRYPTO))
 
 #include <string.h>
 #include "md5.h"


### PR DESCRIPTION
Isolate all platform dependencies into `magic.c`.

Use constructor notation to cause magic to be self-initializing.

Remove dependency on pthreads.

This PR should go in **before** PR #72 or PR #78.