### PR TITLE
source ip interface/address 

### DIFF
--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -186,7 +186,7 @@ int _pam_account(pam_handle_t *pamh, int argc, const char **argv, int type,
 	status = PAM_SESSION_ERR;
 	for (srv_i = 0; srv_i < tac_srv_no; srv_i++) {
 		tac_fd = tac_connect_single(tac_srv[srv_i].addr, tac_srv[srv_i].key,
-				NULL, tac_timeout);
+				tac_src_addr_info, tac_timeout);
 		if (tac_fd < 0) {
 			_pam_log(LOG_WARNING, "%s: error sending %s (fd)", __FUNCTION__,
 					typemsg);
@@ -287,7 +287,7 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 			syslog(LOG_DEBUG, "%s: trying srv %d", __FUNCTION__, srv_i);
 
 		tac_fd = tac_connect_single(tac_srv[srv_i].addr, tac_srv[srv_i].key,
-				NULL, tac_timeout);
+				tac_src_addr_info, tac_timeout);
 		if (tac_fd < 0) {
 			_pam_log(LOG_ERR, "connection failed srv %d: %m", srv_i);
 			active_server.addr = NULL;
@@ -607,8 +607,8 @@ int pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc,
 	if (tac_protocol[0] != '\0')
 		tac_add_attrib(&attr, "protocol", tac_protocol);
 
-	tac_fd = tac_connect_single(active_server.addr, active_server.key, NULL,
-			tac_timeout);
+	tac_fd = tac_connect_single(active_server.addr, active_server.key,
+			tac_src_addr_info, tac_timeout);
 	if (tac_fd < 0) {
 		_pam_log(LOG_ERR, "TACACS+ server unavailable");
 		if (arep.msg != NULL)
@@ -801,7 +801,7 @@ int pam_sm_chauthtok(pam_handle_t * pamh, int flags, int argc,
 			syslog(LOG_DEBUG, "%s: trying srv %d", __FUNCTION__, srv_i);
 
 		tac_fd = tac_connect_single(tac_srv[srv_i].addr, tac_srv[srv_i].key,
-				NULL, tac_timeout);
+				tac_src_addr_info, tac_timeout);
 		if (tac_fd < 0) {
 			_pam_log(LOG_ERR, "connection failed srv %d: %m", srv_i);
 			continue;

--- a/support.c
+++ b/support.c
@@ -29,7 +29,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <bsd/string.h> /* strlcpy */
 
 tacplus_server_t tac_srv[TAC_PLUS_MAXSERVERS];
 int tac_srv_no = 0;
@@ -208,7 +207,7 @@ static void set_tac_srv_key (unsigned int srv_no, const char *key)
 {
     if (srv_no < TAC_PLUS_MAXSERVERS) {
         if (key) {
-            strlcpy (tac_srv_key[srv_no], key, TAC_SECRET_MAX_LEN);
+            strncpy (tac_srv_key[srv_no], key, TAC_SECRET_MAX_LEN-1);
             tac_srv[srv_no].key = tac_srv_key[srv_no];
         }
         else {

--- a/support.h
+++ b/support.h
@@ -39,6 +39,7 @@ extern int tac_srv_no;
 extern char tac_service[64];
 extern char tac_protocol[64];
 extern char tac_prompt[64];
+extern struct addrinfo *tac_src_addr_info;
 void tac_copy_addr_info (struct addrinfo *p_dst, const struct addrinfo *p_src);
 
 int _pam_parse (int, const char **);


### PR DESCRIPTION
This patch adds code in _pam_parse() to parse new option "source_ip" and stores the converted address information in static memory. The address info is then used when calling tac_connect_single().