### PR TITLE
Fix damage from PR #71

### DIFF
--- a/libtac/lib/authen_r.c
+++ b/libtac/lib/authen_r.c
@@ -161,7 +161,7 @@ int tac_authen_read(int fd, struct areply *re) {
 	}
 
 	TACDEBUG(LOG_DEBUG, "%s: authentication failed, server reply status=%d",
-					__FUNCTION__, r);
+					__FUNCTION__, re->status);
 
 	free(tb);
 	return re->status;


### PR DESCRIPTION
`r` as a return value was deprecated with the introduction of `re->status` but we missed an instance in a `TACDEBUG()` 

One line fix.