### PR TITLE
Add runtime debugging

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ if TACC
 bin_PROGRAMS = tacc
 tacc_SOURCES = tacc.c
 tacc_LDADD = libtac.la
-tacc_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include
+tacc_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include @rt_debug_defines@
 endif
 
 libtac_includedir = $(includedir)/libtac
@@ -51,7 +51,7 @@ libtac_la_SOURCES += \
 libtac/lib/md5.c \
 libtac/lib/md5.h
 endif
-libtac_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include
+libtac_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include @rt_debug_defines@
 libtac_la_LDFLAGS = -version-info 2:0:0 -shared
 
 moduledir = @pamdir@

--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,14 @@ AC_ARG_ENABLE(doc, AS_HELP_STRING([--disable-doc], [do not build docs]))
 AM_CONDITIONAL(DOC, test "x$enable_doc" != "xno")
 
 dnl --------------------------------------------------------------------
+dnl Switch for run-time debugging
+AC_ARG_ENABLE(runtime-debugging, [AS_HELP_STRING([--enable-runtime-debugging],
+	      [Build with run-time debugging])],
+	      [rt_debug_defines="-DTACDEBUG_AT_RUNTIME=1"])
+AC_SUBST(rt_debug_defines)
+AM_SUBST_NOTMAKE(rt_debug_defines)
+
+dnl --------------------------------------------------------------------
 dnl Generate made files
 AC_CONFIG_FILES([Makefile
 		 libtac.pc

--- a/libtac.pc.in
+++ b/libtac.pc.in
@@ -8,4 +8,4 @@ Description: A TACACS+ protocol client implementation
 URL: https://github.com/jeroennijhof/pam_tacplus
 Version: @VERSION@
 Libs: -L${libdir} -ltac
-Cflags: -I${includedir}
+Cflags: -I${includedir} @rt_debug_defines@

--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -64,13 +64,13 @@ extern "C" {
 #undef TACDEBUG
 #undef TACSYSLOG
 # ifdef __GNUC__
-#define TACDEBUG(level, fmt, ...) do { if (tac_debug_enable) (void)logmsg(level, fmt, ## __VA_ARGS__); } while (0)
-#define TACSYSLOG(level, fmt, ...) (void)logmsg(level, fmt, ## __VA_ARGS__)
+#define TACDEBUG(level, fmt, ...) do { if (tac_debug_enable) logmsg(level, fmt, ## __VA_ARGS__); } while (0)
+#define TACSYSLOG(level, fmt, ...) logmsg(level, fmt, ## __VA_ARGS__)
 # else
-#define TACDEBUG(level, fmt, ...) do { if (tac_debug_enable) (void)logmsg(level, fmt, __VA_ARGS__); } while (0)
-#define TACSYSLOG(level, fmt, ...) (void)logmsg(level, fmt, __VA_ARGS__)
+#define TACDEBUG(level, fmt, ...) do { if (tac_debug_enable) logmsg(level, fmt, __VA_ARGS__); } while (0)
+#define TACSYSLOG(level, fmt, ...) logmsg(level, fmt, __VA_ARGS__)
 # endif
-extern int logmsg __P((int, const char*, ...));
+extern void logmsg __P((int, const char*, ...));
 #endif
 
 /* u_int32_t support for sun */

--- a/tacc.c
+++ b/tacc.c
@@ -28,6 +28,7 @@
 #include <getopt.h>
 #include <ctype.h>
 #include <openssl/rand.h>
+#include <stdarg.h>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -569,3 +570,17 @@ void timeout_handler(int signum) {
 
 	syslog(LOG_ERR, "timeout reading password from user %s", user);
 }
+
+#ifdef TACDEBUG_AT_RUNTIME
+void logmsg(int level, const char *fmt, ...)
+{
+	va_list ap;
+
+	level = level;				/* unused */
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+}
+#endif


### PR DESCRIPTION
This introduces the `--enable-runtime-debugging` option for`./configure`, which then adds  `-DTACDEBUG_AT_RUNTIME=1` into CFLAGS when building (and exports the flag into `libtac.pc` as well).

This should go in after PR #84.