### PR TITLE
Do not set password for ASCII login

### DIFF
--- a/libtac/lib/authen_s.c
+++ b/libtac/lib/authen_s.c
@@ -130,6 +130,12 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
 			tb.authen_type = TAC_PLUS_AUTHEN_TYPE_PAP;
 		}
 	}
+
+	/* data field is not used in ASCII login */
+	if (tb.authen_type == TAC_PLUS_AUTHEN_TYPE_ASCII) {
+		token_len = 0;
+	}
+
 	tb.service = tac_authen_service;
 	tb.user_len = user_len;
 	tb.port_len = port_len;


### PR DESCRIPTION
For ASCII login, data field is not used ([1] Section 9.0.2 Inbound ASCII Login).
So do not add the user password for the login authentication with type ASCII.

[1] https://tools.ietf.org/html/draft-grant-tacacs-02