### PR TITLE
Fix URL of 'All Contributors' in AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 Primary Authors:
-	Pawel Krawczyk <pawel.krawczyk@hush.com>
-	Jeroen Nijhof <jeroen@jeroennijhof.nl>
+    Pawel Krawczyk <pawel.krawczyk@hush.com>
+    Jeroen Nijhof <jeroen@jeroennijhof.nl>
 All Contributors:
-    https://github.com/pwdng/pam_tacplus/graphs/contributors
+    https://github.com/jeroennijhof/pam_tacplus/graphs/contributors


### PR DESCRIPTION
- Fix: Change url of 'All Contributors' to the original repository and not a forked one