### PR TITLE
Set Travis to build against Trusty Tahr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_install:
   - sudo apt-get install -y libpam-dev
 
 script: autoreconf -i && ./configure && make
+dist: trusty


### PR DESCRIPTION
Per the [announcement](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) Travis is switching to Trusty Tahr as the default build environment.