### PR TITLE
Deprecated OpenSSL RAND_pseudo_bytes()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ dnl Checks for libraries.
 AC_CHECK_LIB(pam, pam_start)
 AC_CHECK_LIB(tac, tac_connect)
 AC_CHECK_LIB(crypto, MD5_Init)
-AC_CHECK_LIB(crypto, RAND_pseudo_bytes)
+AC_CHECK_LIB(crypto, RAND_bytes)
 AC_CHECK_LIB(util, logwtmp)
 
 case "$host" in
@@ -51,7 +51,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h str
 AC_CHECK_HEADERS([syslog.h unistd.h openssl/md5.h openssl/rand.h linux/random.h sys/random.h])
 AC_CHECK_HEADER(security/pam_appl.h, [], [AC_MSG_ERROR([PAM libraries missing. Install with "yum install pam-devel" or "apt-get install libpam-dev".])] )
 AM_CONDITIONAL(MY_MD5, [test "$ac_cv_header_openssl_md5_h" = "no" ])
-AM_CONDITIONAL(TACC, [test "$ac_cv_lib_crypto_RAND_pseudo_bytes" = "yes"])
+AM_CONDITIONAL(TACC, [test "$ac_cv_lib_crypto_RAND_bytes" = "yes"])
 
 dnl --------------------------------------------------------------------
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,10 @@ dnl Checks for libraries.
 AC_CHECK_LIB(pam, pam_start)
 AC_CHECK_LIB(tac, tac_connect)
 AC_CHECK_LIB(crypto, MD5_Init)
-AC_CHECK_LIB(crypto, RAND_bytes)
+AC_CHECK_LIB(crypto, RAND_pseudo_bytes,
+            [AC_DEFINE([HAVE_RAND_PSEUDO_BYTES], [1], [RAND_pseudo_bytes is present])])
+AC_CHECK_LIB(crypto, RAND_bytes,
+             [AC_DEFINE([HAVE_RAND_BYTES], [1], [RAND_bytes is present])])
 AC_CHECK_LIB(util, logwtmp)
 
 case "$host" in
@@ -51,7 +54,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h str
 AC_CHECK_HEADERS([syslog.h unistd.h openssl/md5.h openssl/rand.h linux/random.h sys/random.h])
 AC_CHECK_HEADER(security/pam_appl.h, [], [AC_MSG_ERROR([PAM libraries missing. Install with "yum install pam-devel" or "apt-get install libpam-dev".])] )
 AM_CONDITIONAL(MY_MD5, [test "$ac_cv_header_openssl_md5_h" = "no" ])
-AM_CONDITIONAL(TACC, [test "$ac_cv_lib_crypto_RAND_bytes" = "yes"])
+AM_CONDITIONAL(TACC, [test "$ac_cv_lib_crypto_RAND_bytes" = "yes" -o "$ac_cv_lib_crypto_RAND_pseudo_bytes" = "yes"])
 
 dnl --------------------------------------------------------------------
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -63,8 +63,11 @@ magic()
 {
     u_int32_t num;
 
+#ifdef HAVE_RAND_BYTES
     RAND_bytes((unsigned char *)&num, sizeof(num));
-
+#else
+    RAND_pseudo_bytes((unsigned char *)&num, sizeof(num));
+#endif
     return num;
 }
 

--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -63,7 +63,7 @@ magic()
 {
     u_int32_t num;
 
-    RAND_pseudo_bytes((unsigned char *)&num, sizeof(num));
+    RAND_bytes((unsigned char *)&num, sizeof(num));
 
     return num;
 }

--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -711,7 +711,11 @@ PAM_EXTERN
 int pam_sm_open_session(pam_handle_t * pamh, int flags, int argc,
 		const char **argv) {
 #if defined(HAVE_OPENSSL_RAND_H) && defined(HAVE_LIBCRYPTO)
+#ifdef HAVE_RAND_BYTES
 	RAND_bytes((unsigned char *) &task_id, sizeof(task_id));
+#else
+	RAND_pseudo_bytes((unsigned char *) &task_id, sizeof(task_id));
+#endif
 #else
 	task_id=(short int) magic();
 #endif

--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -711,7 +711,7 @@ PAM_EXTERN
 int pam_sm_open_session(pam_handle_t * pamh, int flags, int argc,
 		const char **argv) {
 #if defined(HAVE_OPENSSL_RAND_H) && defined(HAVE_LIBCRYPTO)
-	RAND_pseudo_bytes((unsigned char *) &task_id, sizeof(task_id));
+	RAND_bytes((unsigned char *) &task_id, sizeof(task_id));
 #else
 	task_id=(short int) magic();
 #endif

--- a/tacc.c
+++ b/tacc.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv) {
 		struct tac_attrib *attr = NULL;
 		sprintf(buf, "%lu", time(0));
 		tac_add_attrib(&attr, "start_time", buf);
-		RAND_pseudo_bytes((unsigned char *) &task_id, sizeof(task_id));
+		RAND_bytes((unsigned char *) &task_id, sizeof(task_id));
 		sprintf(buf, "%hu", task_id);
 		tac_add_attrib(&attr, "task_id", buf);
 		tac_add_attrib(&attr, "service", service);

--- a/tacc.c
+++ b/tacc.c
@@ -316,7 +316,11 @@ int main(int argc, char **argv) {
 		struct tac_attrib *attr = NULL;
 		sprintf(buf, "%lu", time(0));
 		tac_add_attrib(&attr, "start_time", buf);
+#ifdef HAVE_RAND_BYTES
 		RAND_bytes((unsigned char *) &task_id, sizeof(task_id));
+#else
+		RAND_pseudo_bytes((unsigned char *) &task_id, sizeof(task_id));
+#endif
 		sprintf(buf, "%hu", task_id);
 		tac_add_attrib(&attr, "task_id", buf);
 		tac_add_attrib(&attr, "service", service);


### PR DESCRIPTION
`RAND_pseudo_bytes()` has been deprecated in OpenSSL 1.1.0. Need to use `RAND_bytes()` instead.

Ref. https://www.openssl.org/docs/man1.1.0/crypto/RAND_bytes.html 