### PR TITLE
Fix compile-time warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,8 +47,8 @@ esac
 dnl --------------------------------------------------------------------
 dnl Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h strings.h sys/socket.h sys/time.h ])
-AC_CHECK_HEADERS([syslog.h unistd.h openssl/md5.h openssl/rand.h linux/random.h sys/random.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h strings.h sys/socket.h sys/time.h])
+AC_CHECK_HEADERS([syslog.h unistd.h openssl/md5.h openssl/rand.h sys/random.h])
 AC_CHECK_HEADER(security/pam_appl.h, [], [AC_MSG_ERROR([PAM libraries missing. Install with "yum install pam-devel" or "apt-get install libpam-dev".])] )
 AM_CONDITIONAL(MY_MD5, [test "$ac_cv_header_openssl_md5_h" = "no" ])
 AM_CONDITIONAL(TACC, [test "$ac_cv_lib_crypto_RAND_pseudo_bytes" = "yes"])

--- a/libtac/lib/author_r.c
+++ b/libtac/lib/author_r.c
@@ -187,6 +187,7 @@ int tac_author_read(int fd, struct areply *re) {
 	/* XXX support optional vs mandatory arguments */
 	case TAC_PLUS_AUTHOR_STATUS_PASS_REPL:
 		tac_free_attrib(&re->attr);
+		/*FALLTHRU*/
 
 	case TAC_PLUS_AUTHOR_STATUS_PASS_ADD: {
 		u_char *argp;

--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -70,10 +70,10 @@ magic()
 
 #elif defined(HAVE_GETRANDOM)
 
-# if defined(HAVE_LINUX_RANDOM_H)
-#  include <linux/random.h>
-# elif defined(HAVE_SYS_RANDOM_H)
+# if defined(HAVE_SYS_RANDOM_H)
 #  include <sys/random.h>
+# else
+#  error no header containing getrandom(2) declaration
 # endif
 
 /*

--- a/tacc.c
+++ b/tacc.c
@@ -58,7 +58,6 @@
 
 /* prototypes */
 void sighandler(int sig);
-void showusage(char *argv0);
 unsigned long getservername(char *serv);
 void showusage(char *progname);
 void showversion(char *progname);
@@ -163,8 +162,12 @@ int main(int argc, char **argv) {
 				break;
 			case 'V':
 				showversion(argv[0]);
+				/*NOTREACHED*/
+				break;
 			case 'h':
 				showusage(argv[0]);
+				/*NOTREACHED*/
+				break;
 			case 'u':
 				user = optarg;
 				break;


### PR DESCRIPTION
Also, `<linux/random..h>` defines the flags for `getrandom(2)` but doesn't actually declare the function.  For that we need `<sys/random.h>` so include that.