### PR TITLE
Add SElinux tips

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -93,6 +93,10 @@ of `autoconf'.
      targets like `make install' and `make uninstall' work correctly.
      This target is generally not run by end users.
 
+  9. If you're running SElinux in Enforcing mode, you need to set
+     your policy controls appropriately.  For Fedora/RHEL/CentOS, this
+     is done with "setsebool -P nis_enabled 1" (as root).
+
 Compilers and Options
 =====================
 


### PR DESCRIPTION
Per Alex Tomko's findings, SElinux users will need to tweak their policy to accommodate `pam_tacplus`.  We explain how in the `INSTALL` document.