### PR TITLE
Retire logwtmp() in favor of POSIX pututxline()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,9 @@ AC_CHECK_LIB(crypto, RAND_pseudo_bytes,
             [AC_DEFINE([HAVE_RAND_PSEUDO_BYTES], [1], [Define to 1 if you have the `RAND_pseudo_bytes' function.])])
 AC_CHECK_LIB(crypto, RAND_bytes,
              [AC_DEFINE([HAVE_RAND_BYTES], [1], [Define to 1 if you have the `RAND_bytes' function.])])
-AC_CHECK_LIB(util, logwtmp)
+AC_CHECK_LIB(c, pututxline,
+	     [AC_DEFINE([HAVE_PUTUTXLINE], [1], [Define to 1 if you have the `pututxline' function.])],
+	     [AC_CHECK_LIB(util, logwtmp)])
 
 case "$host" in
 	sparc-* | sparc64-*)

--- a/tacc.c
+++ b/tacc.c
@@ -176,8 +176,7 @@ int main(int argc, char **argv) {
 				break;
 			case 'L':
 				// tac_login is a global variable initialized in libtac
-				bzero(tac_login, sizeof(tac_login));
-				strncpy(tac_login, optarg, sizeof(tac_login) - 1);
+				xstrcpy(tac_login, optarg, sizeof(tac_login));
 				break;
 			case 'p':
 				pass = optarg;


### PR DESCRIPTION
Favor POSIX functions for portability wherever possible.