### PR TITLE
Use __thread (thread-local storage) keyword for pthread-safe

### DIFF
--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -145,19 +145,19 @@ extern int tac_ver_minor;
 extern int tac_ver_patch;
 
 /* header.c */
-extern int session_id;
-extern int tac_encryption;
-extern const char *tac_secret;
-extern char tac_login[64];
-extern int tac_priv_lvl;
-extern int tac_authen_method;
-extern int tac_authen_service;
+extern __thread int session_id;
+extern __thread int tac_encryption;
+extern __thread const char *tac_secret;
+extern __thread char tac_login[64];
+extern __thread int tac_priv_lvl;
+extern __thread int tac_authen_method;
+extern __thread int tac_authen_service;
 
-extern int tac_debug_enable;
-extern int tac_readtimeout_enable;
+extern __thread int tac_debug_enable;
+extern __thread int tac_readtimeout_enable;
 
 /* connect.c */
-extern int tac_timeout;
+extern __thread int tac_timeout;
 
 int tac_connect(struct addrinfo **, char **, int);
 int tac_connect_single(const struct addrinfo *, const char *, struct addrinfo *,

--- a/libtac/lib/connect.c
+++ b/libtac/lib/connect.c
@@ -32,7 +32,7 @@
 #include "libtac.h"
 
 /* Pointer to TACACS+ connection timeout */
-int tac_timeout = 5;
+__thread int tac_timeout = 5;
 
 /* Returns file descriptor of open connection
    to the first available server from list passed
@@ -186,7 +186,7 @@ bomb:
  *   (which some ppl don't like, but it's robust and at last no more memory leaks)
  */
 char *tac_ntop(const struct sockaddr *sa) {
-    static char server_address[INET6_ADDRSTRLEN+16];
+    static __thread char server_address[INET6_ADDRSTRLEN+16];
 
     switch(sa->sa_family) {
         case AF_INET:

--- a/libtac/lib/header.c
+++ b/libtac/lib/header.c
@@ -32,31 +32,31 @@
  * store their values between different functions and connections.
  */
 /* Session identifier. */
-int session_id;
+__thread int session_id;
 
 /* Encryption flag. */
-int tac_encryption = 0;
+__thread int tac_encryption = 0;
 
 /* Pointer to TACACS+ shared secret string. */
 /* note: tac_secret will point to tacplus_server[i].key */
-const char *tac_secret = NULL;
+__thread const char *tac_secret = NULL;
 
 /* TACACS+ shared login string. */
-char tac_login[64]; /* default is PAP */
+__thread char tac_login[64]; /* default is PAP */
 
 /* priv_lvl */
-int tac_priv_lvl = TAC_PLUS_PRIV_LVL_MIN;
+__thread int tac_priv_lvl = TAC_PLUS_PRIV_LVL_MIN;
 
 /* Authentication Method */
-int tac_authen_method = TAC_PLUS_AUTHEN_METH_TACACSPLUS;
+__thread int tac_authen_method = TAC_PLUS_AUTHEN_METH_TACACSPLUS;
 
 /* Service requesting authentication */
-int tac_authen_service = TAC_PLUS_AUTHEN_SVC_PPP;
+__thread int tac_authen_service = TAC_PLUS_AUTHEN_SVC_PPP;
 
 /* additional runtime flags */
 
-int tac_debug_enable = 0;
-int tac_readtimeout_enable = 0;
+__thread int tac_debug_enable = 0;
+__thread int tac_readtimeout_enable = 0;
 
 /* Returns pre-filled TACACS+ packet header of given type.
  * 1. you MUST fill th->datalength and th->version

--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -48,13 +48,13 @@
 #endif
 
 /* address of server discovered by pam_sm_authenticate */
-static tacplus_server_t active_server;
-struct addrinfo active_addrinfo;
-struct sockaddr active_sockaddr;
-char active_key[TAC_SECRET_MAX_LEN+1];
+static __thread tacplus_server_t active_server;
+__thread struct addrinfo active_addrinfo;
+__thread struct sockaddr active_sockaddr;
+__thread char active_key[TAC_SECRET_MAX_LEN+1];
 
 /* accounting task identifier */
-static short int task_id = 0;
+static __thread short int task_id = 0;
 
 /* copy a server's information into active_server */
 static void set_active_server (const tacplus_server_t *tac_svr)
@@ -127,7 +127,7 @@ int _pam_account(pam_handle_t *pamh, int argc, const char **argv, int type,
 		char *cmd) {
 
 	int retval;
-	static int ctrl;
+	int ctrl;
 	char *user = NULL;
 	char *tty = NULL;
 	char *r_addr = NULL;

--- a/support.c
+++ b/support.c
@@ -30,15 +30,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-tacplus_server_t tac_srv[TAC_PLUS_MAXSERVERS];
-int tac_srv_no = 0;
+__thread tacplus_server_t tac_srv[TAC_PLUS_MAXSERVERS];
+__thread int tac_srv_no = 0;
 
-char tac_service[64];
-char tac_protocol[64];
-char tac_prompt[64];
-struct addrinfo tac_srv_addr[TAC_PLUS_MAXSERVERS];
-struct sockaddr tac_sock_addr[TAC_PLUS_MAXSERVERS];
-char tac_srv_key[TAC_PLUS_MAXSERVERS][TAC_SECRET_MAX_LEN+1];
+__thread char tac_service[64];
+__thread char tac_protocol[64];
+__thread char tac_prompt[64];
+__thread struct addrinfo tac_srv_addr[TAC_PLUS_MAXSERVERS];
+__thread struct sockaddr tac_sock_addr[TAC_PLUS_MAXSERVERS];
+__thread char tac_srv_key[TAC_PLUS_MAXSERVERS][TAC_SECRET_MAX_LEN+1];
 
 void _pam_log(int err, const char *format,...) {
     char msg[256];

--- a/support.h
+++ b/support.h
@@ -33,12 +33,12 @@ typedef struct {
     const char *key;
 } tacplus_server_t;
 
-extern tacplus_server_t tac_srv[TAC_PLUS_MAXSERVERS];
-extern int tac_srv_no;
+extern __thread tacplus_server_t tac_srv[TAC_PLUS_MAXSERVERS];
+extern __thread int tac_srv_no;
 
-extern char tac_service[64];
-extern char tac_protocol[64];
-extern char tac_prompt[64];
+extern __thread char tac_service[64];
+extern __thread char tac_protocol[64];
+extern __thread char tac_prompt[64];
 void tac_copy_addr_info (struct addrinfo *p_dst, const struct addrinfo *p_src);
 
 int _pam_parse (int, const char **);

--- a/tacc.c
+++ b/tacc.c
@@ -78,7 +78,7 @@ void timeout_handler(int signum);
 #define USE_SYSTEM	1
 
 /* globals */
-int tac_encryption = 1;
+__thread int tac_encryption = 1;
 typedef unsigned char flag;
 flag quiet = 0;
 char *user = NULL; /* global, because of signal handler */


### PR DESCRIPTION
C99 supports Thread-Local Storage:
  https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Thread_002dLocal.html

This patch makes use of "__thread" storage class keyword to make the code
pthread-safe without changing the code much:

- Changed all global variables which can be modified by multiple threads
- Changed static varible in tac_ntop()
- Removed unnecessary "static" from local variable in _pam_account()