### PR TITLE
Fix getrandom call in magic.c

### DIFF
--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -18,6 +18,7 @@
  * See `CHANGES' file for revision history.
  */
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>


### PR DESCRIPTION
_GNU_SOURCE must be defined before any includes to be able to use
getrandom

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>