### PR TITLE
Fix compilation of tacc.c with GCC 8

### DIFF
--- a/tacc.c
+++ b/tacc.c
@@ -375,7 +375,8 @@ int main(int argc, char **argv) {
 		utmpx.ut_type = USER_PROCESS;
 		utmpx.ut_pid = getpid();
 		xstrcpy(utmpx.ut_line, tty, sizeof(utmpx.ut_line));
-		strncpy(utmpx.ut_id, tty + C_STRLEN("tty"), sizeof(utmpx.ut_id));
+		strncpy(utmpx.ut_id, tty + C_STRLEN("tty"), sizeof(utmpx.ut_id) - 1);
+		utmpx.ut_id[sizeof(utmpx.ut_id) - 1] = '\0';
 		xstrcpy(utmpx.ut_host, "dialup", sizeof(utmpx.ut_host));
 		utmpx.ut_tv.tv_sec = tv.tv_sec;
 		utmpx.ut_tv.tv_usec = tv.tv_usec;


### PR DESCRIPTION
GCC 8 demands that the size of the string copied by strncpy be smaller
than the size of the destination to keep space for the trailibg '\0':

tacc.c:378:3: error: 'strncpy' specified bound 4 equals destination size [-Werror=stringop-truncation]
   strncpy(utmpx.ut_id, tty + C_STRLEN("tty"), sizeof(utmpx.ut_id));

Ensure that no more than sizeof(utmpx.ut_id) - 1 characters are copied
and that a trailing '\0' is stored.

Fixes:
  http://autobuild.buildroot.net/results/da6d150e470046c03c5f7463de045604e15e4a30/

Signed-off-by: Carlos Santos <casantos@datacom.com.br>